### PR TITLE
Add CommunityToolkit.Mvvm and update ViewModels

### DIFF
--- a/GymMate/GymMate/GymMate.csproj
+++ b/GymMate/GymMate/GymMate.csproj
@@ -59,9 +59,10 @@
 		<MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
 	</ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
-	</ItemGroup>
+        <ItemGroup>
+                <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+                <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
+                <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
+        </ItemGroup>
 
 </Project>

--- a/GymMate/GymMate/ViewModels/HomeViewModel.cs
+++ b/GymMate/GymMate/ViewModels/HomeViewModel.cs
@@ -1,5 +1,16 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
 namespace GymMate.ViewModels;
 
-public class HomeViewModel
+public partial class HomeViewModel : ObservableObject
 {
+    [ObservableProperty]
+    private int count;
+
+    [ICommand]
+    private void IncrementCount()
+    {
+        Count++;
+    }
 }

--- a/GymMate/GymMate/ViewModels/LoginViewModel.cs
+++ b/GymMate/GymMate/ViewModels/LoginViewModel.cs
@@ -1,5 +1,12 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
 namespace GymMate.ViewModels;
 
-public class LoginViewModel
+public partial class LoginViewModel : ObservableObject
 {
+    [ObservableProperty]
+    private string email = string.Empty;
+
+    [ObservableProperty]
+    private string password = string.Empty;
 }


### PR DESCRIPTION
## Summary
- add `CommunityToolkit.Mvvm` package reference
- implement `HomeViewModel` using `ObservableObject` with a count property and command
- implement `LoginViewModel` with observable Email and Password properties

## Testing
- `dotnet build GymMate/GymMate.sln -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f3fb9e96c832f8d33f04a748c331e