### PR TITLE
Implement workout routines module

### DIFF
--- a/GymMate/GymMate/AppShell.xaml.cs
+++ b/GymMate/GymMate/AppShell.xaml.cs
@@ -6,6 +6,8 @@
         {
             InitializeComponent();
             Routing.RegisterRoute("resttimer", typeof(Views.RestTimerPage));
+            Routing.RegisterRoute("routines", typeof(Views.RoutinesPage));
+            Routing.RegisterRoute("routineDetail", typeof(Views.RoutineDetailPage));
         }
     }
 }

--- a/GymMate/GymMate/MauiProgram.cs
+++ b/GymMate/GymMate/MauiProgram.cs
@@ -32,6 +32,10 @@ namespace GymMate
             builder.Services.AddSingleton<IRealtimeDbService, RealtimeDbService>();
             builder.Services.AddTransient<ViewModels.RestTimerViewModel>();
             builder.Services.AddTransient<Views.RestTimerPage>();
+            builder.Services.AddTransient<ViewModels.RoutinesViewModel>();
+            builder.Services.AddTransient<Views.RoutinesPage>();
+            builder.Services.AddTransient<ViewModels.RoutineDetailViewModel>();
+            builder.Services.AddTransient<Views.RoutineDetailPage>();
 
 #if DEBUG
     		builder.Logging.AddDebug();

--- a/GymMate/GymMate/Messages/RoutineMessages.cs
+++ b/GymMate/GymMate/Messages/RoutineMessages.cs
@@ -1,0 +1,7 @@
+namespace GymMate.Messages;
+
+using GymMate.Models;
+
+public record RoutineUpdatedMessage(WorkoutRoutine Routine);
+public record RoutineDeletedMessage(string RoutineId);
+public record RoutinesReloadMessage();

--- a/GymMate/GymMate/Models/WorkoutRoutine.cs
+++ b/GymMate/GymMate/Models/WorkoutRoutine.cs
@@ -1,0 +1,9 @@
+namespace GymMate.Models;
+
+public class WorkoutRoutine
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public DateTime CreatedUtc { get; set; } = DateTime.UtcNow;
+}

--- a/GymMate/GymMate/Services/FirebaseAuthService.cs
+++ b/GymMate/GymMate/Services/FirebaseAuthService.cs
@@ -5,10 +5,12 @@ public interface IFirebaseAuthService
     Task<bool> LoginAsync(string email, string password);
     Task<bool> RegisterAsync(string email, string password);
     Task LogoutAsync();
+    string CurrentUserUid { get; }
 }
 
 public class FirebaseAuthService : IFirebaseAuthService
 {
+    public string CurrentUserUid { get; private set; } = "debug-user";
     public Task<bool> LoginAsync(string email, string password)
     {
         // TODO: Integrate Firebase Auth login

--- a/GymMate/GymMate/Services/RealtimeDbService.cs
+++ b/GymMate/GymMate/Services/RealtimeDbService.cs
@@ -3,13 +3,55 @@ namespace GymMate.Services;
 public interface IRealtimeDbService
 {
     Task SaveUserProfileAsync(string userId, object profile);
+    Task<IEnumerable<Models.WorkoutRoutine>> GetRoutinesAsync(string userId);
+    Task AddOrUpdateRoutineAsync(string userId, Models.WorkoutRoutine routine);
+    Task DeleteRoutineAsync(string userId, string routineId);
+    event EventHandler? RoutinesChanged;
 }
 
 public class RealtimeDbService : IRealtimeDbService
 {
+    private static readonly Dictionary<string, Dictionary<string, Models.WorkoutRoutine>> _routines = new();
+
+    public event EventHandler? RoutinesChanged;
+
     public Task SaveUserProfileAsync(string userId, object profile)
     {
         // TODO: Integrate Firebase realtime database
+        return Task.CompletedTask;
+    }
+
+    public Task<IEnumerable<Models.WorkoutRoutine>> GetRoutinesAsync(string userId)
+    {
+        if (_routines.TryGetValue(userId, out var dict))
+        {
+            return Task.FromResult<IEnumerable<Models.WorkoutRoutine>>(dict.Values.ToList());
+        }
+
+        return Task.FromResult<IEnumerable<Models.WorkoutRoutine>>(Array.Empty<Models.WorkoutRoutine>());
+    }
+
+    public Task AddOrUpdateRoutineAsync(string userId, Models.WorkoutRoutine routine)
+    {
+        if (!_routines.TryGetValue(userId, out var dict))
+        {
+            dict = new();
+            _routines[userId] = dict;
+        }
+
+        dict[routine.Id] = routine;
+        RoutinesChanged?.Invoke(this, EventArgs.Empty);
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteRoutineAsync(string userId, string routineId)
+    {
+        if (_routines.TryGetValue(userId, out var dict))
+        {
+            dict.Remove(routineId);
+        }
+
+        RoutinesChanged?.Invoke(this, EventArgs.Empty);
         return Task.CompletedTask;
     }
 }

--- a/GymMate/GymMate/ViewModels/RoutineDetailViewModel.cs
+++ b/GymMate/GymMate/ViewModels/RoutineDetailViewModel.cs
@@ -1,0 +1,69 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
+using GymMate.Models;
+using GymMate.Messages;
+using GymMate.Services;
+
+namespace GymMate.ViewModels;
+
+public partial class RoutineDetailViewModel : ObservableObject, IQueryAttributable
+{
+    private readonly IRealtimeDbService _db;
+    private readonly IFirebaseAuthService _auth;
+
+    [ObservableProperty]
+    private WorkoutRoutine routine = new();
+
+    public RoutineDetailViewModel(IRealtimeDbService db, IFirebaseAuthService auth)
+    {
+        _db = db;
+        _auth = auth;
+    }
+
+    public void ApplyQueryAttributes(IDictionary<string, object> query)
+    {
+        if (query.TryGetValue("Routine", out var value) && value is WorkoutRoutine r)
+        {
+            Routine = new WorkoutRoutine
+            {
+                Id = r.Id,
+                Name = r.Name,
+                Description = r.Description,
+                CreatedUtc = r.CreatedUtc
+            };
+        }
+        else
+        {
+            Routine = new WorkoutRoutine();
+        }
+    }
+
+    [RelayCommand]
+    private async Task SaveAsync()
+    {
+        var uid = _auth.CurrentUserUid;
+        if (string.IsNullOrEmpty(uid)) return;
+
+        bool isNew = string.IsNullOrEmpty(Routine.Id);
+        if (isNew)
+        {
+            Routine.Id = Guid.NewGuid().ToString();
+            Routine.CreatedUtc = DateTime.UtcNow;
+        }
+
+        WeakReferenceMessenger.Default.Send(new RoutineUpdatedMessage(Routine));
+
+        try
+        {
+            await _db.AddOrUpdateRoutineAsync(uid, Routine);
+        }
+        catch
+        {
+            WeakReferenceMessenger.Default.Send(new RoutinesReloadMessage());
+            await Shell.Current.DisplayAlert("Error", "No se pudo guardar la rutina", "OK");
+        }
+
+        await Shell.Current.GoToAsync("..");
+    }
+}

--- a/GymMate/GymMate/ViewModels/RoutinesViewModel.cs
+++ b/GymMate/GymMate/ViewModels/RoutinesViewModel.cs
@@ -1,0 +1,101 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
+using GymMate.Models;
+using GymMate.Messages;
+using GymMate.Services;
+
+namespace GymMate.ViewModels;
+
+public partial class RoutinesViewModel : ObservableObject
+{
+    private readonly IRealtimeDbService _db;
+    private readonly IFirebaseAuthService _auth;
+
+    public ObservableCollection<WorkoutRoutine> Routines { get; } = new();
+
+    public RoutinesViewModel(IRealtimeDbService db, IFirebaseAuthService auth)
+    {
+        _db = db;
+        _auth = auth;
+        _db.RoutinesChanged += Db_RoutinesChanged;
+        WeakReferenceMessenger.Default.Register<RoutineUpdatedMessage>(this, (r, m) => LocalAddOrUpdate(m.Routine));
+        WeakReferenceMessenger.Default.Register<RoutineDeletedMessage>(this, (r, m) => LocalDelete(m.RoutineId));
+        WeakReferenceMessenger.Default.Register<RoutinesReloadMessage>(this, (r, m) => LoadAsync());
+    }
+
+    private async void Db_RoutinesChanged(object? sender, EventArgs e)
+    {
+        await LoadAsync();
+    }
+
+    [RelayCommand]
+    public async Task AppearingAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        var uid = _auth.CurrentUserUid;
+        if (string.IsNullOrEmpty(uid)) return;
+        var routines = await _db.GetRoutinesAsync(uid);
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            Routines.Clear();
+            foreach (var r in routines.OrderByDescending(x => x.CreatedUtc))
+                Routines.Add(r);
+        });
+    }
+
+    private void LocalAddOrUpdate(WorkoutRoutine routine)
+    {
+        var existing = Routines.FirstOrDefault(r => r.Id == routine.Id);
+        if (existing == null)
+        {
+            Routines.Add(routine);
+        }
+        else
+        {
+            var index = Routines.IndexOf(existing);
+            Routines[index] = routine;
+        }
+    }
+
+    private void LocalDelete(string id)
+    {
+        var existing = Routines.FirstOrDefault(r => r.Id == id);
+        if (existing != null)
+            Routines.Remove(existing);
+    }
+
+    [RelayCommand]
+    private async Task AddAsync()
+    {
+        await Shell.Current.GoToAsync("routineDetail");
+    }
+
+    [RelayCommand]
+    private async Task EditAsync(WorkoutRoutine routine)
+    {
+        await Shell.Current.GoToAsync("routineDetail", new Dictionary<string, object> { ["Routine"] = routine });
+    }
+
+    [RelayCommand]
+    private async Task DeleteAsync(WorkoutRoutine routine)
+    {
+        bool confirm = await Shell.Current.DisplayAlert("Eliminar", $"¿Eliminar {routine.Name}?", "Sí", "No");
+        if (!confirm) return;
+
+        LocalDelete(routine.Id);
+        try
+        {
+            await _db.DeleteRoutineAsync(_auth.CurrentUserUid, routine.Id);
+        }
+        catch
+        {
+            await Shell.Current.DisplayAlert("Error", "No se pudo borrar", "OK");
+            await LoadAsync();
+        }
+    }
+}

--- a/GymMate/GymMate/Views/HomePage.xaml
+++ b/GymMate/GymMate/Views/HomePage.xaml
@@ -34,6 +34,10 @@
                 Text="Descanso"
                 Clicked="OnRestTimerClicked"
                 HorizontalOptions="Fill" />
+            <Button
+                Text="Rutinas"
+                Clicked="OnRoutinesClicked"
+                HorizontalOptions="Fill" />
         </VerticalStackLayout>
     </ScrollView>
 

--- a/GymMate/GymMate/Views/HomePage.xaml.cs
+++ b/GymMate/GymMate/Views/HomePage.xaml.cs
@@ -25,5 +25,10 @@
         {
             await Shell.Current.GoToAsync("resttimer");
         }
+
+        private async void OnRoutinesClicked(object? sender, EventArgs e)
+        {
+            await Shell.Current.GoToAsync("//routines");
+        }
     }
 }

--- a/GymMate/GymMate/Views/RoutineDetailPage.xaml
+++ b/GymMate/GymMate/Views/RoutineDetailPage.xaml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:vm="clr-namespace:GymMate.ViewModels"
+             x:Class="GymMate.Views.RoutineDetailPage"
+             x:DataType="vm:RoutineDetailViewModel">
+    <StackLayout Padding="30" Spacing="20">
+        <Entry Placeholder="Nombre" Text="{Binding Routine.Name}" />
+        <Editor Placeholder="Descripción" Text="{Binding Routine.Description}" AutoSize="TextChanges" />
+        <Button Text="Guardar" Command="{Binding SaveCommand}" />
+    </StackLayout>
+</ContentPage>

--- a/GymMate/GymMate/Views/RoutineDetailPage.xaml.cs
+++ b/GymMate/GymMate/Views/RoutineDetailPage.xaml.cs
@@ -1,0 +1,12 @@
+using GymMate.ViewModels;
+
+namespace GymMate.Views;
+
+public partial class RoutineDetailPage : ContentPage
+{
+    public RoutineDetailPage(RoutineDetailViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+}

--- a/GymMate/GymMate/Views/RoutinesPage.xaml
+++ b/GymMate/GymMate/Views/RoutinesPage.xaml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:vm="clr-namespace:GymMate.ViewModels"
+             xmlns:models="clr-namespace:GymMate.Models"
+             x:Class="GymMate.Views.RoutinesPage"
+             x:DataType="vm:RoutinesViewModel"
+             x:Name="page">
+    <ContentPage.ToolbarItems>
+        <ToolbarItem Text="Add" Command="{Binding AddCommand}" />
+    </ContentPage.ToolbarItems>
+    <CollectionView ItemsSource="{Binding Routines}">
+        <CollectionView.ItemTemplate>
+            <DataTemplate x:DataType="models:WorkoutRoutine">
+                <SwipeView>
+                    <SwipeView.RightItems>
+                        <SwipeItems>
+                            <SwipeItem Text="Edit"
+                                       Command="{Binding Source={x:Reference page}, Path=BindingContext.EditCommand}"
+                                       CommandParameter="{Binding .}" />
+                            <SwipeItem Text="Delete" BackgroundColor="Red"
+                                       Command="{Binding Source={x:Reference page}, Path=BindingContext.DeleteCommand}"
+                                       CommandParameter="{Binding .}" />
+                        </SwipeItems>
+                    </SwipeView.RightItems>
+                    <Grid Padding="10">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Label Text="{Binding Name}" FontAttributes="Bold" />
+                        <Label Text="{Binding Description}" Grid.Row="1" FontSize="Small" />
+                    </Grid>
+                </SwipeView>
+            </DataTemplate>
+        </CollectionView.ItemTemplate>
+    </CollectionView>
+</ContentPage>

--- a/GymMate/GymMate/Views/RoutinesPage.xaml.cs
+++ b/GymMate/GymMate/Views/RoutinesPage.xaml.cs
@@ -1,0 +1,19 @@
+using GymMate.ViewModels;
+
+namespace GymMate.Views;
+
+public partial class RoutinesPage : ContentPage
+{
+    public RoutinesPage(RoutinesViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        if (BindingContext is RoutinesViewModel vm)
+            vm.AppearingCommand.Execute(null);
+    }
+}


### PR DESCRIPTION
## Summary
- extend FirebaseAuthService with `CurrentUserUid`
- implement routine CRUD in RealtimeDbService with in-memory storage
- add WorkoutRoutine model and messenger records
- create RoutinesPage and RoutineDetailPage using MVVM Toolkit
- add navigation and dependency registrations
- add "Rutinas" button on home page

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f459d577c832f9fc42721a537e467