### PR TITLE
Add workout session and progress tracking

### DIFF
--- a/GymMate/GymMate/AppShell.xaml.cs
+++ b/GymMate/GymMate/AppShell.xaml.cs
@@ -8,6 +8,10 @@
             Routing.RegisterRoute("resttimer", typeof(Views.RestTimerPage));
             Routing.RegisterRoute("routines", typeof(Views.RoutinesPage));
             Routing.RegisterRoute("routineDetail", typeof(Views.RoutineDetailPage));
+            Routing.RegisterRoute("sessions", typeof(Views.SessionsPage));
+            Routing.RegisterRoute("sessionEditor", typeof(Views.SessionEditorPage));
+            Routing.RegisterRoute("sessionDetail", typeof(Views.SessionDetailPage));
+            Routing.RegisterRoute("progress", typeof(Views.ProgressPage));
         }
     }
 }

--- a/GymMate/GymMate/GymMate.csproj
+++ b/GymMate/GymMate/GymMate.csproj
@@ -66,6 +66,7 @@
                 <PackageReference Include="Plugin.Firebase.Auth" Version="3.1.1" />
                 <PackageReference Include="Plugin.Firebase.Database" Version="3.1.1" />
                 <PackageReference Include="Plugin.LocalNotification" Version="17.0.0" />
+                <PackageReference Include="Microcharts.Maui" Version="0.9.5" />
         </ItemGroup>
 
 </Project>

--- a/GymMate/GymMate/MauiProgram.cs
+++ b/GymMate/GymMate/MauiProgram.cs
@@ -3,6 +3,7 @@ using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers.Items;
 using Plugin.Firebase;
 using Plugin.LocalNotification;
+using Microcharts.Maui;
 using GymMate.Services;
 
 namespace GymMate
@@ -16,6 +17,7 @@ namespace GymMate
                 .UseMauiApp<App>()
                 .UseFirebaseApp()
                 .UseLocalNotification()
+                .UseMicrocharts()
                 .ConfigureFonts(fonts =>
                 {
                     fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
@@ -36,6 +38,14 @@ namespace GymMate
             builder.Services.AddTransient<Views.RoutinesPage>();
             builder.Services.AddTransient<ViewModels.RoutineDetailViewModel>();
             builder.Services.AddTransient<Views.RoutineDetailPage>();
+            builder.Services.AddTransient<ViewModels.SessionsViewModel>();
+            builder.Services.AddTransient<Views.SessionsPage>();
+            builder.Services.AddTransient<ViewModels.SessionEditorViewModel>();
+            builder.Services.AddTransient<Views.SessionEditorPage>();
+            builder.Services.AddTransient<ViewModels.SessionDetailViewModel>();
+            builder.Services.AddTransient<Views.SessionDetailPage>();
+            builder.Services.AddTransient<ViewModels.ProgressViewModel>();
+            builder.Services.AddTransient<Views.ProgressPage>();
 
 #if DEBUG
     		builder.Logging.AddDebug();

--- a/GymMate/GymMate/Messages/SessionMessages.cs
+++ b/GymMate/GymMate/Messages/SessionMessages.cs
@@ -1,0 +1,7 @@
+namespace GymMate.Messages;
+
+using GymMate.Models;
+
+public record SessionUpdatedMessage(WorkoutSession Session);
+public record SessionDeletedMessage(string SessionId);
+public record SessionsReloadMessage();

--- a/GymMate/GymMate/Models/WorkoutSession.cs
+++ b/GymMate/GymMate/Models/WorkoutSession.cs
@@ -1,0 +1,16 @@
+namespace GymMate.Models;
+
+public class SetRecord
+{
+    public string ExerciseName { get; set; } = string.Empty;
+    public int Reps { get; set; }
+    public double WeightKg { get; set; }
+}
+
+public class WorkoutSession
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public string RoutineId { get; set; } = string.Empty;
+    public DateTime DateUtc { get; set; } = DateTime.UtcNow;
+    public IList<SetRecord> Sets { get; set; } = new List<SetRecord>();
+}

--- a/GymMate/GymMate/Services/RealtimeDbService.cs
+++ b/GymMate/GymMate/Services/RealtimeDbService.cs
@@ -6,14 +6,20 @@ public interface IRealtimeDbService
     Task<IEnumerable<Models.WorkoutRoutine>> GetRoutinesAsync(string userId);
     Task AddOrUpdateRoutineAsync(string userId, Models.WorkoutRoutine routine);
     Task DeleteRoutineAsync(string userId, string routineId);
+    Task<IEnumerable<Models.WorkoutSession>> GetSessionsAsync(string userId);
+    Task AddSessionAsync(string userId, Models.WorkoutSession session);
+    Task DeleteSessionAsync(string userId, string sessionId);
     event EventHandler? RoutinesChanged;
+    event EventHandler? SessionsChanged;
 }
 
 public class RealtimeDbService : IRealtimeDbService
 {
     private static readonly Dictionary<string, Dictionary<string, Models.WorkoutRoutine>> _routines = new();
+    private static readonly Dictionary<string, Dictionary<string, Models.WorkoutSession>> _sessions = new();
 
     public event EventHandler? RoutinesChanged;
+    public event EventHandler? SessionsChanged;
 
     public Task SaveUserProfileAsync(string userId, object profile)
     {
@@ -52,6 +58,40 @@ public class RealtimeDbService : IRealtimeDbService
         }
 
         RoutinesChanged?.Invoke(this, EventArgs.Empty);
+        return Task.CompletedTask;
+    }
+
+    public Task<IEnumerable<Models.WorkoutSession>> GetSessionsAsync(string userId)
+    {
+        if (_sessions.TryGetValue(userId, out var dict))
+        {
+            return Task.FromResult<IEnumerable<Models.WorkoutSession>>(dict.Values.ToList());
+        }
+
+        return Task.FromResult<IEnumerable<Models.WorkoutSession>>(Array.Empty<Models.WorkoutSession>());
+    }
+
+    public Task AddSessionAsync(string userId, Models.WorkoutSession session)
+    {
+        if (!_sessions.TryGetValue(userId, out var dict))
+        {
+            dict = new();
+            _sessions[userId] = dict;
+        }
+
+        dict[session.Id] = session;
+        SessionsChanged?.Invoke(this, EventArgs.Empty);
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteSessionAsync(string userId, string sessionId)
+    {
+        if (_sessions.TryGetValue(userId, out var dict))
+        {
+            dict.Remove(sessionId);
+        }
+
+        SessionsChanged?.Invoke(this, EventArgs.Empty);
         return Task.CompletedTask;
     }
 }

--- a/GymMate/GymMate/ViewModels/ProgressViewModel.cs
+++ b/GymMate/GymMate/ViewModels/ProgressViewModel.cs
@@ -1,0 +1,79 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microcharts;
+using GymMate.Models;
+using GymMate.Services;
+
+namespace GymMate.ViewModels;
+
+public partial class ProgressViewModel : ObservableObject
+{
+    private readonly IRealtimeDbService _db;
+    private readonly IFirebaseAuthService _auth;
+
+    public ObservableCollection<string> Exercises { get; } = new();
+
+    [ObservableProperty]
+    private string? selectedExercise;
+
+    [ObservableProperty]
+    private Chart? chart;
+
+    public ProgressViewModel(IRealtimeDbService db, IFirebaseAuthService auth)
+    {
+        _db = db;
+        _auth = auth;
+    }
+
+    [RelayCommand]
+    public async Task AppearingAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        var uid = _auth.CurrentUserUid;
+        if (string.IsNullOrEmpty(uid)) return;
+        var sessions = await _db.GetSessionsAsync(uid);
+        var names = sessions.SelectMany(s => s.Sets).Select(s => s.ExerciseName).Distinct().OrderBy(x => x);
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            Exercises.Clear();
+            foreach (var n in names) Exercises.Add(n);
+            if (SelectedExercise == null && Exercises.Count > 0) SelectedExercise = Exercises[0];
+        });
+        await UpdateChartAsync(sessions);
+    }
+
+    partial void OnSelectedExerciseChanged(string? value)
+    {
+        _ = RefreshChartAsync();
+    }
+
+    private async Task RefreshChartAsync()
+    {
+        var uid = _auth.CurrentUserUid;
+        if (string.IsNullOrEmpty(uid) || string.IsNullOrEmpty(SelectedExercise)) return;
+        var sessions = await _db.GetSessionsAsync(uid);
+        await UpdateChartAsync(sessions);
+    }
+
+    private Task UpdateChartAsync(IEnumerable<WorkoutSession> sessions)
+    {
+        if (string.IsNullOrEmpty(SelectedExercise)) return Task.CompletedTask;
+        var from = DateTime.UtcNow.AddDays(-30);
+        var data = sessions.Where(s => s.DateUtc >= from)
+            .SelectMany(s => s.Sets.Where(set => set.ExerciseName == SelectedExercise)
+            .Select(set => new { s.DateUtc, set.WeightKg }))
+            .OrderBy(d => d.DateUtc)
+            .ToList();
+        var entries = data.Select(d => new ChartEntry((float)d.WeightKg)
+        {
+            Label = d.DateUtc.ToString("MM-dd"),
+            ValueLabel = d.WeightKg.ToString("0.##")
+        }).ToList();
+        Chart = new LineChart { Entries = entries, LineMode = LineMode.Straight };
+        return Task.CompletedTask;
+    }
+}

--- a/GymMate/GymMate/ViewModels/SessionDetailViewModel.cs
+++ b/GymMate/GymMate/ViewModels/SessionDetailViewModel.cs
@@ -1,0 +1,51 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
+using GymMate.Models;
+using GymMate.Messages;
+using GymMate.Services;
+
+namespace GymMate.ViewModels;
+
+public partial class SessionDetailViewModel : ObservableObject, IQueryAttributable
+{
+    private readonly IRealtimeDbService _db;
+    private readonly IFirebaseAuthService _auth;
+
+    [ObservableProperty]
+    private WorkoutSession session = new();
+
+    public SessionDetailViewModel(IRealtimeDbService db, IFirebaseAuthService auth)
+    {
+        _db = db;
+        _auth = auth;
+    }
+
+    public void ApplyQueryAttributes(IDictionary<string, object> query)
+    {
+        if (query.TryGetValue("Session", out var value) && value is WorkoutSession s)
+        {
+            Session = s;
+        }
+    }
+
+    [RelayCommand]
+    private async Task DeleteAsync()
+    {
+        bool confirm = await Shell.Current.DisplayAlert("Eliminar", "¿Eliminar sesión?", "Sí", "No");
+        if (!confirm) return;
+
+        WeakReferenceMessenger.Default.Send(new SessionDeletedMessage(Session.Id));
+        try
+        {
+            await _db.DeleteSessionAsync(_auth.CurrentUserUid, Session.Id);
+        }
+        catch
+        {
+            WeakReferenceMessenger.Default.Send(new SessionsReloadMessage());
+            await Shell.Current.DisplayAlert("Error", "No se pudo borrar", "OK");
+        }
+
+        await Shell.Current.GoToAsync("..");
+    }
+}

--- a/GymMate/GymMate/ViewModels/SessionEditorViewModel.cs
+++ b/GymMate/GymMate/ViewModels/SessionEditorViewModel.cs
@@ -1,0 +1,80 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
+using GymMate.Models;
+using GymMate.Messages;
+using GymMate.Services;
+
+namespace GymMate.ViewModels;
+
+public partial class SessionEditorViewModel : ObservableObject
+{
+    private readonly IRealtimeDbService _db;
+    private readonly IFirebaseAuthService _auth;
+
+    public ObservableCollection<WorkoutRoutine> Routines { get; } = new();
+    public ObservableCollection<SetRecord> Sets { get; } = new();
+
+    [ObservableProperty]
+    private WorkoutRoutine? selectedRoutine;
+
+    [ObservableProperty]
+    private DateTime date = DateTime.Today;
+
+    public SessionEditorViewModel(IRealtimeDbService db, IFirebaseAuthService auth)
+    {
+        _db = db;
+        _auth = auth;
+    }
+
+    [RelayCommand]
+    public async Task AppearingAsync()
+    {
+        var uid = _auth.CurrentUserUid;
+        if (string.IsNullOrEmpty(uid)) return;
+        var routines = await _db.GetRoutinesAsync(uid);
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            Routines.Clear();
+            foreach (var r in routines.OrderBy(x => x.Name))
+                Routines.Add(r);
+        });
+    }
+
+    [RelayCommand]
+    private void AddSet()
+    {
+        Sets.Add(new SetRecord());
+    }
+
+    [RelayCommand]
+    private async Task SaveAsync()
+    {
+        if (SelectedRoutine == null)
+        {
+            await Shell.Current.DisplayAlert("Error", "Seleccione rutina", "OK");
+            return;
+        }
+
+        var session = new WorkoutSession
+        {
+            Id = Guid.NewGuid().ToString(),
+            RoutineId = SelectedRoutine.Id,
+            DateUtc = Date.ToUniversalTime(),
+            Sets = Sets.ToList()
+        };
+
+        WeakReferenceMessenger.Default.Send(new SessionUpdatedMessage(session));
+        try
+        {
+            await _db.AddSessionAsync(_auth.CurrentUserUid, session);
+        }
+        catch
+        {
+            WeakReferenceMessenger.Default.Send(new SessionsReloadMessage());
+            await Shell.Current.DisplayAlert("Error", "No se pudo guardar", "OK");
+        }
+
+        await Shell.Current.GoToAsync("..");
+    }
+}

--- a/GymMate/GymMate/ViewModels/SessionsViewModel.cs
+++ b/GymMate/GymMate/ViewModels/SessionsViewModel.cs
@@ -1,0 +1,101 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
+using GymMate.Models;
+using GymMate.Messages;
+using GymMate.Services;
+
+namespace GymMate.ViewModels;
+
+public partial class SessionsViewModel : ObservableObject
+{
+    private readonly IRealtimeDbService _db;
+    private readonly IFirebaseAuthService _auth;
+
+    public ObservableCollection<WorkoutSession> Sessions { get; } = new();
+
+    public SessionsViewModel(IRealtimeDbService db, IFirebaseAuthService auth)
+    {
+        _db = db;
+        _auth = auth;
+        _db.SessionsChanged += Db_SessionsChanged;
+        WeakReferenceMessenger.Default.Register<SessionUpdatedMessage>(this, (r, m) => LocalAddOrUpdate(m.Session));
+        WeakReferenceMessenger.Default.Register<SessionDeletedMessage>(this, (r, m) => LocalDelete(m.SessionId));
+        WeakReferenceMessenger.Default.Register<SessionsReloadMessage>(this, (r, m) => LoadAsync());
+    }
+
+    private async void Db_SessionsChanged(object? sender, EventArgs e)
+    {
+        await LoadAsync();
+    }
+
+    [RelayCommand]
+    public async Task AppearingAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        var uid = _auth.CurrentUserUid;
+        if (string.IsNullOrEmpty(uid)) return;
+        var sessions = await _db.GetSessionsAsync(uid);
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            Sessions.Clear();
+            foreach (var s in sessions.OrderByDescending(x => x.DateUtc))
+                Sessions.Add(s);
+        });
+    }
+
+    private void LocalAddOrUpdate(WorkoutSession session)
+    {
+        var existing = Sessions.FirstOrDefault(s => s.Id == session.Id);
+        if (existing == null)
+        {
+            Sessions.Insert(0, session);
+        }
+        else
+        {
+            var index = Sessions.IndexOf(existing);
+            Sessions[index] = session;
+        }
+    }
+
+    private void LocalDelete(string id)
+    {
+        var existing = Sessions.FirstOrDefault(s => s.Id == id);
+        if (existing != null)
+            Sessions.Remove(existing);
+    }
+
+    [RelayCommand]
+    private async Task AddAsync()
+    {
+        await Shell.Current.GoToAsync("sessionEditor");
+    }
+
+    [RelayCommand]
+    private async Task ViewAsync(WorkoutSession session)
+    {
+        await Shell.Current.GoToAsync("sessionDetail", new Dictionary<string, object> { ["Session"] = session });
+    }
+
+    [RelayCommand]
+    private async Task DeleteAsync(WorkoutSession session)
+    {
+        bool confirm = await Shell.Current.DisplayAlert("Eliminar", "¿Eliminar sesión?", "Sí", "No");
+        if (!confirm) return;
+
+        LocalDelete(session.Id);
+        try
+        {
+            await _db.DeleteSessionAsync(_auth.CurrentUserUid, session.Id);
+        }
+        catch
+        {
+            await Shell.Current.DisplayAlert("Error", "No se pudo borrar", "OK");
+            await LoadAsync();
+        }
+    }
+}

--- a/GymMate/GymMate/Views/HomePage.xaml
+++ b/GymMate/GymMate/Views/HomePage.xaml
@@ -38,6 +38,14 @@
                 Text="Rutinas"
                 Clicked="OnRoutinesClicked"
                 HorizontalOptions="Fill" />
+            <Button
+                Text="Sesiones"
+                Clicked="OnSessionsClicked"
+                HorizontalOptions="Fill" />
+            <Button
+                Text="Progreso"
+                Clicked="OnProgressClicked"
+                HorizontalOptions="Fill" />
         </VerticalStackLayout>
     </ScrollView>
 

--- a/GymMate/GymMate/Views/HomePage.xaml.cs
+++ b/GymMate/GymMate/Views/HomePage.xaml.cs
@@ -30,5 +30,15 @@
         {
             await Shell.Current.GoToAsync("//routines");
         }
+
+        private async void OnSessionsClicked(object? sender, EventArgs e)
+        {
+            await Shell.Current.GoToAsync("//sessions");
+        }
+
+        private async void OnProgressClicked(object? sender, EventArgs e)
+        {
+            await Shell.Current.GoToAsync("progress");
+        }
     }
 }

--- a/GymMate/GymMate/Views/ProgressPage.xaml
+++ b/GymMate/GymMate/Views/ProgressPage.xaml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:vm="clr-namespace:GymMate.ViewModels"
+             xmlns:chart="clr-namespace:Microcharts.Maui;assembly=Microcharts.Maui"
+             x:Class="GymMate.Views.ProgressPage"
+             x:DataType="vm:ProgressViewModel">
+    <StackLayout Padding="30" Spacing="20">
+        <Picker ItemsSource="{Binding Exercises}" SelectedItem="{Binding SelectedExercise}" />
+        <chart:ChartView Chart="{Binding Chart}" HeightRequest="300" />
+    </StackLayout>
+</ContentPage>

--- a/GymMate/GymMate/Views/ProgressPage.xaml.cs
+++ b/GymMate/GymMate/Views/ProgressPage.xaml.cs
@@ -1,0 +1,19 @@
+using GymMate.ViewModels;
+
+namespace GymMate.Views;
+
+public partial class ProgressPage : ContentPage
+{
+    public ProgressPage(ProgressViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        if (BindingContext is ProgressViewModel vm)
+            vm.AppearingCommand.Execute(null);
+    }
+}

--- a/GymMate/GymMate/Views/SessionDetailPage.xaml
+++ b/GymMate/GymMate/Views/SessionDetailPage.xaml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:vm="clr-namespace:GymMate.ViewModels"
+             xmlns:models="clr-namespace:GymMate.Models"
+             x:Class="GymMate.Views.SessionDetailPage"
+             x:DataType="vm:SessionDetailViewModel">
+    <StackLayout Padding="30" Spacing="10">
+        <Label Text="{Binding Session.DateUtc, StringFormat='{0:dd/MM/yyyy}'}" FontAttributes="Bold" />
+        <CollectionView ItemsSource="{Binding Session.Sets}">
+            <CollectionView.ItemTemplate>
+                <DataTemplate x:DataType="models:SetRecord">
+                    <Grid ColumnDefinitions="*,Auto,Auto" Padding="0,5">
+                        <Label Text="{Binding ExerciseName}" />
+                        <Label Grid.Column="1" Text="{Binding Reps}" />
+                        <Label Grid.Column="2" Text="{Binding WeightKg}" />
+                    </Grid>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+        <Button Text="Eliminar" Command="{Binding DeleteCommand}" />
+    </StackLayout>
+</ContentPage>

--- a/GymMate/GymMate/Views/SessionDetailPage.xaml.cs
+++ b/GymMate/GymMate/Views/SessionDetailPage.xaml.cs
@@ -1,0 +1,12 @@
+using GymMate.ViewModels;
+
+namespace GymMate.Views;
+
+public partial class SessionDetailPage : ContentPage
+{
+    public SessionDetailPage(SessionDetailViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+}

--- a/GymMate/GymMate/Views/SessionEditorPage.xaml
+++ b/GymMate/GymMate/Views/SessionEditorPage.xaml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:vm="clr-namespace:GymMate.ViewModels"
+             xmlns:models="clr-namespace:GymMate.Models"
+             x:Class="GymMate.Views.SessionEditorPage"
+             x:DataType="vm:SessionEditorViewModel">
+    <ScrollView>
+        <VerticalStackLayout Padding="30" Spacing="20">
+            <Picker Title="Rutina" ItemsSource="{Binding Routines}" ItemDisplayBinding="{Binding Name}" SelectedItem="{Binding SelectedRoutine}" />
+            <DatePicker Date="{Binding Date}" />
+            <CollectionView ItemsSource="{Binding Sets}">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate x:DataType="models:SetRecord">
+                        <Grid ColumnDefinitions="*,Auto,Auto" Padding="0,5">
+                            <Entry Placeholder="Ejercicio" Text="{Binding ExerciseName}" />
+                            <Entry Grid.Column="1" WidthRequest="60" Keyboard="Numeric" Placeholder="Reps" Text="{Binding Reps}" />
+                            <Entry Grid.Column="2" WidthRequest="80" Keyboard="Numeric" Placeholder="Kg" Text="{Binding WeightKg}" />
+                        </Grid>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+            <Button Text="Añadir set" Command="{Binding AddSetCommand}" />
+            <Button Text="Guardar" Command="{Binding SaveCommand}" />
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/GymMate/GymMate/Views/SessionEditorPage.xaml.cs
+++ b/GymMate/GymMate/Views/SessionEditorPage.xaml.cs
@@ -1,0 +1,19 @@
+using GymMate.ViewModels;
+
+namespace GymMate.Views;
+
+public partial class SessionEditorPage : ContentPage
+{
+    public SessionEditorPage(SessionEditorViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        if (BindingContext is SessionEditorViewModel vm)
+            vm.AppearingCommand.Execute(null);
+    }
+}

--- a/GymMate/GymMate/Views/SessionsPage.xaml
+++ b/GymMate/GymMate/Views/SessionsPage.xaml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:vm="clr-namespace:GymMate.ViewModels"
+             xmlns:models="clr-namespace:GymMate.Models"
+             x:Class="GymMate.Views.SessionsPage"
+             x:DataType="vm:SessionsViewModel"
+             x:Name="page">
+    <ContentPage.ToolbarItems>
+        <ToolbarItem Text="Add" Command="{Binding AddCommand}" />
+    </ContentPage.ToolbarItems>
+    <CollectionView ItemsSource="{Binding Sessions}">
+        <CollectionView.ItemTemplate>
+            <DataTemplate x:DataType="models:WorkoutSession">
+                <SwipeView>
+                    <SwipeView.RightItems>
+                        <SwipeItems>
+                            <SwipeItem Text="View"
+                                       Command="{Binding Source={x:Reference page}, Path=BindingContext.ViewCommand}"
+                                       CommandParameter="{Binding .}" />
+                            <SwipeItem Text="Delete" BackgroundColor="Red"
+                                       Command="{Binding Source={x:Reference page}, Path=BindingContext.DeleteCommand}"
+                                       CommandParameter="{Binding .}" />
+                        </SwipeItems>
+                    </SwipeView.RightItems>
+                    <Grid Padding="10">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Label Text="{Binding DateUtc, StringFormat='{0:dd/MM/yyyy}'}" FontAttributes="Bold" />
+                        <Label Text="{Binding Sets.Count, StringFormat='{0} sets'}" Grid.Row="1" FontSize="Small" />
+                    </Grid>
+                </SwipeView>
+            </DataTemplate>
+        </CollectionView.ItemTemplate>
+    </CollectionView>
+</ContentPage>

--- a/GymMate/GymMate/Views/SessionsPage.xaml.cs
+++ b/GymMate/GymMate/Views/SessionsPage.xaml.cs
@@ -1,0 +1,19 @@
+using GymMate.ViewModels;
+
+namespace GymMate.Views;
+
+public partial class SessionsPage : ContentPage
+{
+    public SessionsPage(SessionsViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        if (BindingContext is SessionsViewModel vm)
+            vm.AppearingCommand.Execute(null);
+    }
+}


### PR DESCRIPTION
## Summary
- model workout sessions and set records
- expand realtime DB service to handle sessions
- implement view models and pages for session CRUD
- show progress chart with Microcharts
- add navigation routes and Home buttons
- register services and use Microcharts in `MauiProgram`

## Testing
- `dotnet build GymMate.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f46e3ffc0832fbb7a232fce0f53f8