### PR TITLE
Integrate push notifications with settings

### DIFF
--- a/GymMate/GymMate/AppShell.xaml.cs
+++ b/GymMate/GymMate/AppShell.xaml.cs
@@ -12,6 +12,7 @@
             Routing.RegisterRoute("sessionEditor", typeof(Views.SessionEditorPage));
             Routing.RegisterRoute("sessionDetail", typeof(Views.SessionDetailPage));
             Routing.RegisterRoute("progress", typeof(Views.ProgressPage));
+            Routing.RegisterRoute("settings", typeof(Views.SettingsPage));
         }
     }
 }

--- a/GymMate/GymMate/GymMate.csproj
+++ b/GymMate/GymMate/GymMate.csproj
@@ -66,6 +66,7 @@
                 <PackageReference Include="Plugin.Firebase.Auth" Version="3.1.1" />
                 <PackageReference Include="Plugin.Firebase.Database" Version="3.1.1" />
                 <PackageReference Include="Plugin.LocalNotification" Version="17.0.0" />
+                <PackageReference Include="Plugin.Firebase.CloudMessaging" Version="3.1.1" />
                 <PackageReference Include="Microcharts.Maui" Version="0.9.5" />
         </ItemGroup>
 

--- a/GymMate/GymMate/MauiProgram.cs
+++ b/GymMate/GymMate/MauiProgram.cs
@@ -2,6 +2,7 @@
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers.Items;
 using Plugin.Firebase;
+using Plugin.Firebase.CloudMessaging;
 using Plugin.LocalNotification;
 using Microcharts.Maui;
 using GymMate.Services;
@@ -16,6 +17,7 @@ namespace GymMate
             builder
                 .UseMauiApp<App>()
                 .UseFirebaseApp()
+                .UseFirebaseCloudMessaging()
                 .UseLocalNotification()
                 .UseMicrocharts()
                 .ConfigureFonts(fonts =>
@@ -32,6 +34,7 @@ namespace GymMate
 
             builder.Services.AddSingleton<IFirebaseAuthService, FirebaseAuthService>();
             builder.Services.AddSingleton<IRealtimeDbService, RealtimeDbService>();
+            builder.Services.AddSingleton<INotificationService, NotificationService>();
             builder.Services.AddTransient<ViewModels.RestTimerViewModel>();
             builder.Services.AddTransient<Views.RestTimerPage>();
             builder.Services.AddTransient<ViewModels.RoutinesViewModel>();
@@ -46,6 +49,8 @@ namespace GymMate
             builder.Services.AddTransient<Views.SessionDetailPage>();
             builder.Services.AddTransient<ViewModels.ProgressViewModel>();
             builder.Services.AddTransient<Views.ProgressPage>();
+            builder.Services.AddTransient<ViewModels.SettingsViewModel>();
+            builder.Services.AddTransient<Views.SettingsPage>();
 
 #if DEBUG
     		builder.Logging.AddDebug();

--- a/GymMate/GymMate/Platforms/Android/AndroidManifest.xml
+++ b/GymMate/GymMate/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
-	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-	<uses-permission android:name="android.permission.INTERNET" />
+        <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+        <uses-permission android:name="android.permission.INTERNET" />
+        <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+        <uses-permission android:name="android.permission.WAKE_LOCK" />
+        <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 </manifest>

--- a/GymMate/GymMate/Platforms/Android/MainActivity.cs
+++ b/GymMate/GymMate/Platforms/Android/MainActivity.cs
@@ -1,11 +1,24 @@
 ﻿using Android.App;
 using Android.Content.PM;
 using Android.OS;
+using Android.Content;
+using Plugin.Firebase.CloudMessaging;
 
 namespace GymMate
 {
     [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
     public class MainActivity : MauiAppCompatActivity
     {
+        protected override void OnCreate(Bundle? savedInstanceState)
+        {
+            base.OnCreate(savedInstanceState);
+            FirebasePushNotificationManager.ProcessIntent(this, Intent);
+        }
+
+        protected override void OnNewIntent(Intent? intent)
+        {
+            base.OnNewIntent(intent);
+            FirebasePushNotificationManager.ProcessIntent(this, intent);
+        }
     }
 }

--- a/GymMate/GymMate/Services/NotificationService.cs
+++ b/GymMate/GymMate/Services/NotificationService.cs
@@ -1,0 +1,58 @@
+namespace GymMate.Services;
+
+using Plugin.Firebase.CloudMessaging;
+using Plugin.LocalNotification;
+
+public interface INotificationService
+{
+    Task RequestPermissionsAsync();
+    Task ScheduleLocalAsync(DateTime when, string title, string body, string id);
+    Task SubscribeToTopicAsync(string topic);
+    Task UnsubscribeFromTopicAsync(string topic);
+}
+
+public class NotificationService : INotificationService
+{
+    private readonly IRealtimeDbService _db;
+    private readonly IFirebaseAuthService _auth;
+
+    public NotificationService(IRealtimeDbService db, IFirebaseAuthService auth)
+    {
+        _db = db;
+        _auth = auth;
+        CrossFirebaseCloudMessaging.Current.TokenRefreshed += OnTokenRefreshed;
+    }
+
+    private async void OnTokenRefreshed(object? sender, string token)
+    {
+        var uid = _auth.CurrentUserUid;
+        if (string.IsNullOrEmpty(uid)) return;
+        await _db.SaveDeviceTokenAsync(uid, token);
+    }
+
+    public Task RequestPermissionsAsync()
+        => CrossFirebaseCloudMessaging.Current.RequestPermissionAsync();
+
+    public Task ScheduleLocalAsync(DateTime when, string title, string body, string id)
+    {
+        var request = new NotificationRequest
+        {
+            NotificationId = id.GetHashCode(),
+            Title = title,
+            Description = body,
+            Schedule = new NotificationRequestSchedule
+            {
+                NotifyTime = when,
+                RepeatType = NotificationRepeat.Daily
+            }
+        };
+        NotificationCenter.Current.Show(request);
+        return Task.CompletedTask;
+    }
+
+    public Task SubscribeToTopicAsync(string topic)
+        => CrossFirebaseCloudMessaging.Current.SubscribeToTopic(topic);
+
+    public Task UnsubscribeFromTopicAsync(string topic)
+        => CrossFirebaseCloudMessaging.Current.UnsubscribeFromTopic(topic);
+}

--- a/GymMate/GymMate/Services/RealtimeDbService.cs
+++ b/GymMate/GymMate/Services/RealtimeDbService.cs
@@ -9,6 +9,7 @@ public interface IRealtimeDbService
     Task<IEnumerable<Models.WorkoutSession>> GetSessionsAsync(string userId);
     Task AddSessionAsync(string userId, Models.WorkoutSession session);
     Task DeleteSessionAsync(string userId, string sessionId);
+    Task SaveDeviceTokenAsync(string userId, string token);
     event EventHandler? RoutinesChanged;
     event EventHandler? SessionsChanged;
 }
@@ -17,6 +18,7 @@ public class RealtimeDbService : IRealtimeDbService
 {
     private static readonly Dictionary<string, Dictionary<string, Models.WorkoutRoutine>> _routines = new();
     private static readonly Dictionary<string, Dictionary<string, Models.WorkoutSession>> _sessions = new();
+    private static readonly Dictionary<string, HashSet<string>> _tokens = new();
 
     public event EventHandler? RoutinesChanged;
     public event EventHandler? SessionsChanged;
@@ -92,6 +94,18 @@ public class RealtimeDbService : IRealtimeDbService
         }
 
         SessionsChanged?.Invoke(this, EventArgs.Empty);
+        return Task.CompletedTask;
+    }
+
+    public Task SaveDeviceTokenAsync(string userId, string token)
+    {
+        if (!_tokens.TryGetValue(userId, out var set))
+        {
+            set = new();
+            _tokens[userId] = set;
+        }
+
+        set.Add(token);
         return Task.CompletedTask;
     }
 }

--- a/GymMate/GymMate/ViewModels/SettingsViewModel.cs
+++ b/GymMate/GymMate/ViewModels/SettingsViewModel.cs
@@ -1,0 +1,64 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Maui.Storage;
+
+using GymMate.Services;
+
+namespace GymMate.ViewModels;
+
+public partial class SettingsViewModel(INotificationService notifications) : ObservableObject
+{
+    private readonly INotificationService _notifications = notifications;
+
+    [ObservableProperty]
+    private bool dailyRemindersEnabled;
+
+    [ObservableProperty]
+    private TimeSpan dailyReminderTime = new(8,0,0);
+
+    [ObservableProperty]
+    private bool newRoutinesAlertsEnabled;
+
+    partial void OnDailyRemindersEnabledChanged(bool value)
+    {
+        Preferences.Set(nameof(DailyRemindersEnabled), value);
+        if (value)
+            ScheduleReminder();
+    }
+
+    partial void OnDailyReminderTimeChanged(TimeSpan value)
+    {
+        Preferences.Set(nameof(DailyReminderTime), value.ToString());
+        if (DailyRemindersEnabled)
+            ScheduleReminder();
+    }
+
+    partial void OnNewRoutinesAlertsEnabledChanged(bool value)
+    {
+        Preferences.Set(nameof(NewRoutinesAlertsEnabled), value);
+        if (value)
+            _notifications.SubscribeToTopicAsync("new-routines");
+        else
+            _notifications.UnsubscribeFromTopicAsync("new-routines");
+    }
+
+    [RelayCommand]
+    private Task RequestPermissionsAsync() => _notifications.RequestPermissionsAsync();
+
+    private void ScheduleReminder()
+    {
+        var when = DateTime.Today.Add(DailyReminderTime);
+        if (when <= DateTime.Now)
+            when = when.AddDays(1);
+        _notifications.ScheduleLocalAsync(when, "GymMate", "Hora de entrenar", "daily_reminder");
+    }
+
+    public void Load()
+    {
+        DailyRemindersEnabled = Preferences.Get(nameof(DailyRemindersEnabled), false);
+        var time = Preferences.Get(nameof(DailyReminderTime), "08:00:00");
+        TimeSpan.TryParse(time, out dailyReminderTime);
+        OnPropertyChanged(nameof(DailyReminderTime));
+        NewRoutinesAlertsEnabled = Preferences.Get(nameof(NewRoutinesAlertsEnabled), false);
+    }
+}

--- a/GymMate/GymMate/Views/HomePage.xaml
+++ b/GymMate/GymMate/Views/HomePage.xaml
@@ -2,6 +2,9 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="GymMate.Views.HomePage">
+    <ContentPage.ToolbarItems>
+        <ToolbarItem Text="⚙️" Clicked="OnSettingsClicked" Priority="0" Order="Primary" />
+    </ContentPage.ToolbarItems>
 
     <ScrollView>
         <VerticalStackLayout

--- a/GymMate/GymMate/Views/HomePage.xaml.cs
+++ b/GymMate/GymMate/Views/HomePage.xaml.cs
@@ -40,5 +40,10 @@
         {
             await Shell.Current.GoToAsync("progress");
         }
+
+        private async void OnSettingsClicked(object? sender, EventArgs e)
+        {
+            await Shell.Current.GoToAsync("settings");
+        }
     }
 }

--- a/GymMate/GymMate/Views/SettingsPage.xaml
+++ b/GymMate/GymMate/Views/SettingsPage.xaml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:vm="clr-namespace:GymMate.ViewModels"
+             x:Class="GymMate.Views.SettingsPage"
+             x:DataType="vm:SettingsViewModel">
+    <VerticalStackLayout Padding="30" Spacing="20">
+        <HorizontalStackLayout>
+            <Label Text="Recordatorios diarios" VerticalOptions="Center" />
+            <Switch IsToggled="{Binding DailyRemindersEnabled}" />
+        </HorizontalStackLayout>
+        <TimePicker Time="{Binding DailyReminderTime}" />
+        <HorizontalStackLayout>
+            <Label Text="Avisos de nuevas rutinas" VerticalOptions="Center" />
+            <Switch IsToggled="{Binding NewRoutinesAlertsEnabled}" />
+        </HorizontalStackLayout>
+    </VerticalStackLayout>
+</ContentPage>

--- a/GymMate/GymMate/Views/SettingsPage.xaml.cs
+++ b/GymMate/GymMate/Views/SettingsPage.xaml.cs
@@ -1,0 +1,13 @@
+using GymMate.ViewModels;
+
+namespace GymMate.Views;
+
+public partial class SettingsPage : ContentPage
+{
+    public SettingsPage(SettingsViewModel vm)
+    {
+        InitializeComponent();
+        BindingContext = vm;
+        vm.Load();
+    }
+}


### PR DESCRIPTION
## Summary
- add Firebase Cloud Messaging package
- implement `NotificationService` for local and push notifications
- store FCM tokens through `RealtimeDbService`
- wire up notification service in `MauiProgram`
- register settings page route and add settings button on home page
- implement `SettingsViewModel` and UI to manage reminders and topic subscriptions
- process FCM intents on Android and request necessary permissions

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684f491e67fc832fb6c2e813f076f005