### PR TITLE
Add social feed module

### DIFF
--- a/GymMate/GymMate/AppShell.xaml.cs
+++ b/GymMate/GymMate/AppShell.xaml.cs
@@ -16,6 +16,7 @@
             Routing.RegisterRoute("photos", typeof(Views.PhotosPage));
             Routing.RegisterRoute("photoDetail", typeof(Views.PhotoDetailPage));
             Routing.RegisterRoute("progress", typeof(Views.ProgressPage));
+            Routing.RegisterRoute("feed", typeof(Views.FeedPage));
             Routing.RegisterRoute("settings", typeof(Views.SettingsPage));
         }
     }

--- a/GymMate/GymMate/MauiProgram.cs
+++ b/GymMate/GymMate/MauiProgram.cs
@@ -39,6 +39,7 @@ namespace GymMate
             builder.Services.AddSingleton<INotificationService, NotificationService>();
             builder.Services.AddSingleton<IClassBookingService, ClassBookingService>();
             builder.Services.AddSingleton<IProgressPhotoService, ProgressPhotoService>();
+            builder.Services.AddSingleton<IFeedService, FeedService>();
             builder.Services.AddTransient<ViewModels.RestTimerViewModel>();
             builder.Services.AddTransient<Views.RestTimerPage>();
             builder.Services.AddTransient<ViewModels.RoutinesViewModel>();
@@ -59,6 +60,8 @@ namespace GymMate
             builder.Services.AddTransient<Views.PhotosPage>();
             builder.Services.AddTransient<ViewModels.PhotoDetailViewModel>();
             builder.Services.AddTransient<Views.PhotoDetailPage>();
+            builder.Services.AddTransient<ViewModels.FeedViewModel>();
+            builder.Services.AddTransient<Views.FeedPage>();
             builder.Services.AddTransient<ViewModels.ProgressViewModel>();
             builder.Services.AddTransient<Views.ProgressPage>();
             builder.Services.AddTransient<ViewModels.SettingsViewModel>();

--- a/GymMate/GymMate/Models/FeedPost.cs
+++ b/GymMate/GymMate/Models/FeedPost.cs
@@ -1,0 +1,11 @@
+namespace GymMate.Models;
+
+public class FeedPost
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public string AuthorUid { get; set; } = string.Empty;
+    public string PhotoUrl { get; set; } = string.Empty;
+    public string? Caption { get; set; }
+    public DateTime UploadedUtc { get; set; } = DateTime.UtcNow;
+    public int LikesCount { get; set; }
+}

--- a/GymMate/GymMate/Services/FeedService.cs
+++ b/GymMate/GymMate/Services/FeedService.cs
@@ -1,0 +1,95 @@
+namespace GymMate.Services;
+
+using GymMate.Models;
+
+public interface IFeedService
+{
+    IAsyncEnumerable<FeedPost> GetLatestAsync(int pageSize = 20, DateTime? startAfter = null);
+    Task CreatePostAsync(ProgressPhoto photo);
+    Task LikeAsync(string postId, string uid);
+    Task UnlikeAsync(string postId, string uid);
+    Task<bool> IsLikedAsync(string postId, string uid);
+    event EventHandler<FeedPost>? PostUpdated;
+}
+
+public class FeedService : IFeedService
+{
+    private static readonly Dictionary<string, FeedPost> _posts = new();
+    private static readonly Dictionary<string, HashSet<string>> _likes = new();
+    private readonly IFirebaseAuthService _auth;
+
+    public event EventHandler<FeedPost>? PostUpdated;
+
+    public FeedService(IFirebaseAuthService auth)
+    {
+        _auth = auth;
+    }
+
+    public async IAsyncEnumerable<FeedPost> GetLatestAsync(int pageSize = 20, DateTime? startAfter = null)
+    {
+        var list = _posts.Values
+            .OrderByDescending(p => p.UploadedUtc)
+            .ToList();
+        if (startAfter != null)
+            list = list.Where(p => p.UploadedUtc < startAfter).ToList();
+        foreach (var p in list.Take(pageSize))
+        {
+            yield return p;
+            await Task.Yield();
+        }
+    }
+
+    public Task CreatePostAsync(ProgressPhoto photo)
+    {
+        var uid = _auth.CurrentUserUid;
+        if (string.IsNullOrEmpty(uid)) return Task.CompletedTask;
+        var post = new FeedPost
+        {
+            AuthorUid = uid,
+            PhotoUrl = photo.Url,
+            Caption = photo.Caption,
+            UploadedUtc = DateTime.UtcNow,
+            LikesCount = 0
+        };
+        _posts[post.Id] = post;
+        PostUpdated?.Invoke(this, post);
+        return Task.CompletedTask;
+    }
+
+    public Task LikeAsync(string postId, string uid)
+    {
+        if (!_posts.TryGetValue(postId, out var post))
+            return Task.CompletedTask;
+        if (!_likes.TryGetValue(postId, out var set))
+        {
+            set = new();
+            _likes[postId] = set;
+        }
+        if (set.Add(uid))
+        {
+            post.LikesCount = set.Count;
+            PostUpdated?.Invoke(this, post);
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task UnlikeAsync(string postId, string uid)
+    {
+        if (!_posts.TryGetValue(postId, out var post))
+            return Task.CompletedTask;
+        if (_likes.TryGetValue(postId, out var set) && set.Remove(uid))
+        {
+            post.LikesCount = set.Count;
+            PostUpdated?.Invoke(this, post);
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task<bool> IsLikedAsync(string postId, string uid)
+    {
+        if (_likes.TryGetValue(postId, out var set))
+            return Task.FromResult(set.Contains(uid));
+        return Task.FromResult(false);
+    }
+}
+

--- a/GymMate/GymMate/ViewModels/FeedViewModel.cs
+++ b/GymMate/GymMate/ViewModels/FeedViewModel.cs
@@ -1,0 +1,96 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using GymMate.Models;
+using GymMate.Services;
+using System.Collections.ObjectModel;
+
+namespace GymMate.ViewModels;
+
+public partial class FeedViewModel : ObservableObject
+{
+    private readonly IFeedService _service;
+    private readonly IFirebaseAuthService _auth;
+
+    public ObservableCollection<FeedPost> Posts { get; } = new();
+
+    private DateTime? _lastDate;
+
+    [ObservableProperty]
+    private bool isBusy;
+
+    [ObservableProperty]
+    private bool isRefreshing;
+
+    public FeedViewModel(IFeedService service, IFirebaseAuthService auth)
+    {
+        _service = service;
+        _auth = auth;
+        _service.PostUpdated += Service_PostUpdated;
+    }
+
+    private void Service_PostUpdated(object? sender, FeedPost e)
+    {
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            var existing = Posts.FirstOrDefault(p => p.Id == e.Id);
+            if (existing == null)
+            {
+                Posts.Insert(0, e);
+            }
+            else
+            {
+                var index = Posts.IndexOf(existing);
+                Posts[index] = e;
+            }
+        });
+    }
+
+    [RelayCommand]
+    public async Task AppearingAsync()
+    {
+        if (Posts.Count == 0)
+            await LoadMoreAsync();
+    }
+
+    [RelayCommand]
+    private async Task RefreshAsync()
+    {
+        IsRefreshing = true;
+        Posts.Clear();
+        _lastDate = null;
+        await LoadMoreAsync();
+        IsRefreshing = false;
+    }
+
+    [RelayCommand]
+    public async Task LoadMoreAsync()
+    {
+        if (IsBusy) return;
+        IsBusy = true;
+        var list = new List<FeedPost>();
+        await foreach (var p in _service.GetLatestAsync(20, _lastDate))
+            list.Add(p);
+        if (list.Count > 0)
+            _lastDate = list.Last().UploadedUtc;
+        foreach (var p in list)
+            Posts.Add(p);
+        IsBusy = false;
+    }
+
+    [RelayCommand]
+    private Task ToggleLikeAsync(FeedPost post)
+    {
+        var uid = _auth.CurrentUserUid;
+        if (string.IsNullOrEmpty(uid)) return Task.CompletedTask;
+        if (post == null) return Task.CompletedTask;
+        return ToggleAsync(post, uid);
+    }
+
+    private async Task ToggleAsync(FeedPost post, string uid)
+    {
+        if (await _service.IsLikedAsync(post.Id, uid))
+            await _service.UnlikeAsync(post.Id, uid);
+        else
+            await _service.LikeAsync(post.Id, uid);
+    }
+}

--- a/GymMate/GymMate/ViewModels/PhotoDetailViewModel.cs
+++ b/GymMate/GymMate/ViewModels/PhotoDetailViewModel.cs
@@ -8,13 +8,15 @@ namespace GymMate.ViewModels;
 public partial class PhotoDetailViewModel : ObservableObject, IQueryAttributable
 {
     private readonly IProgressPhotoService _service;
+    private readonly IFeedService _feed;
 
     [ObservableProperty]
     private ProgressPhoto photo = new();
 
-    public PhotoDetailViewModel(IProgressPhotoService service)
+    public PhotoDetailViewModel(IProgressPhotoService service, IFeedService feed)
     {
         _service = service;
+        _feed = feed;
     }
 
     public void ApplyQueryAttributes(IDictionary<string, object> query)
@@ -31,5 +33,12 @@ public partial class PhotoDetailViewModel : ObservableObject, IQueryAttributable
 
         await _service.DeleteAsync(Photo.Id);
         await Shell.Current.GoToAsync("..");
+    }
+
+    [RelayCommand]
+    private async Task ShareAsync()
+    {
+        await _feed.CreatePostAsync(Photo);
+        await Shell.Current.DisplayAlert("Compartido", "Se publicó en el feed", "OK");
     }
 }

--- a/GymMate/GymMate/Views/FeedPage.xaml
+++ b/GymMate/GymMate/Views/FeedPage.xaml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:vm="clr-namespace:GymMate.ViewModels"
+             xmlns:models="clr-namespace:GymMate.Models"
+             xmlns:ff="clr-namespace:FFImageLoading.Maui;assembly=Maui.FFImageLoading"
+             x:Class="GymMate.Views.FeedPage"
+             x:DataType="vm:FeedViewModel"
+             x:Name="page">
+    <CollectionView ItemsSource="{Binding Posts}"
+                    RemainingItemsThreshold="5"
+                    RemainingItemsThresholdReachedCommand="{Binding LoadMoreCommand}"
+                    IsPullToRefreshEnabled="True"
+                    IsRefreshing="{Binding IsRefreshing}"
+                    RefreshCommand="{Binding RefreshCommand}">
+        <CollectionView.EmptyView>
+            <Label Text="No hay posts todavía" HorizontalOptions="Center" VerticalOptions="Center" />
+        </CollectionView.EmptyView>
+        <CollectionView.ItemTemplate>
+            <DataTemplate x:DataType="models:FeedPost">
+                <VerticalStackLayout Padding="10" Spacing="5">
+                    <ff:CachedImage Source="{Binding PhotoUrl}" Aspect="AspectFill" HeightRequest="300" />
+                    <Label Text="{Binding Caption}" />
+                    <HorizontalStackLayout>
+                        <Label Text="{Binding LikesCount}" />
+                        <Button Text="❤️" Command="{Binding Source={x:Reference page}, Path=BindingContext.ToggleLikeCommand}" CommandParameter="{Binding .}" />
+                    </HorizontalStackLayout>
+                </VerticalStackLayout>
+            </DataTemplate>
+        </CollectionView.ItemTemplate>
+    </CollectionView>
+</ContentPage>

--- a/GymMate/GymMate/Views/FeedPage.xaml.cs
+++ b/GymMate/GymMate/Views/FeedPage.xaml.cs
@@ -1,0 +1,9 @@
+namespace GymMate.Views;
+
+public partial class FeedPage : ContentPage
+{
+    public FeedPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/GymMate/GymMate/Views/HomePage.xaml
+++ b/GymMate/GymMate/Views/HomePage.xaml
@@ -57,6 +57,10 @@
                 Text="Fotos"
                 Clicked="OnPhotosClicked"
                 HorizontalOptions="Fill" />
+            <Button
+                Text="Feed"
+                Clicked="OnFeedClicked"
+                HorizontalOptions="Fill" />
         </VerticalStackLayout>
     </ScrollView>
 

--- a/GymMate/GymMate/Views/HomePage.xaml.cs
+++ b/GymMate/GymMate/Views/HomePage.xaml.cs
@@ -51,6 +51,11 @@
             await Shell.Current.GoToAsync("//photos");
         }
 
+        private async void OnFeedClicked(object? sender, EventArgs e)
+        {
+            await Shell.Current.GoToAsync("//feed");
+        }
+
         private async void OnSettingsClicked(object? sender, EventArgs e)
         {
             await Shell.Current.GoToAsync("settings");

--- a/GymMate/GymMate/Views/PhotoDetailPage.xaml
+++ b/GymMate/GymMate/Views/PhotoDetailPage.xaml
@@ -11,6 +11,7 @@
             <Label Text="{Binding Photo.UploadedUtc, StringFormat='{0:dd/MM/yyyy HH:mm}'}" />
             <Label Text="{Binding Photo.Caption}" />
             <Button Text="Eliminar" Command="{Binding DeleteCommand}" />
+            <Button Text="Compartir en feed" Command="{Binding ShareCommand}" />
         </VerticalStackLayout>
     </ScrollView>
 </ContentPage>


### PR DESCRIPTION
## Summary
- add FeedPost model for feed posts
- implement FeedService with in‑memory storage
- integrate FeedViewModel and FeedPage UI
- register feed service and page in DI
- add feed navigation and share button from photos

## Testing
- `dotnet build -v q` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f4dde5f5c832fa4b5d1f73d1681e3