### PR TITLE
Add comments to feed

### DIFF
--- a/GymMate/GymMate/AppShell.xaml.cs
+++ b/GymMate/GymMate/AppShell.xaml.cs
@@ -17,6 +17,7 @@
             Routing.RegisterRoute("photoDetail", typeof(Views.PhotoDetailPage));
             Routing.RegisterRoute("progress", typeof(Views.ProgressPage));
             Routing.RegisterRoute("feed", typeof(Views.FeedPage));
+            Routing.RegisterRoute("comments", typeof(Views.CommentsPage));
             Routing.RegisterRoute("settings", typeof(Views.SettingsPage));
         }
     }

--- a/GymMate/GymMate/MauiProgram.cs
+++ b/GymMate/GymMate/MauiProgram.cs
@@ -62,6 +62,8 @@ namespace GymMate
             builder.Services.AddTransient<Views.PhotoDetailPage>();
             builder.Services.AddTransient<ViewModels.FeedViewModel>();
             builder.Services.AddTransient<Views.FeedPage>();
+            builder.Services.AddTransient<ViewModels.CommentsViewModel>();
+            builder.Services.AddTransient<Views.CommentsPage>();
             builder.Services.AddTransient<ViewModels.ProgressViewModel>();
             builder.Services.AddTransient<Views.ProgressPage>();
             builder.Services.AddTransient<ViewModels.SettingsViewModel>();

--- a/GymMate/GymMate/Models/FeedComment.cs
+++ b/GymMate/GymMate/Models/FeedComment.cs
@@ -1,0 +1,10 @@
+namespace GymMate.Models;
+
+public class FeedComment
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public string AuthorUid { get; set; } = string.Empty;
+    public string Text { get; set; } = string.Empty;
+    public DateTime CreatedUtc { get; set; } = DateTime.UtcNow;
+    public bool IsMine { get; set; }
+}

--- a/GymMate/GymMate/ViewModels/CommentsViewModel.cs
+++ b/GymMate/GymMate/ViewModels/CommentsViewModel.cs
@@ -1,0 +1,89 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using GymMate.Models;
+using GymMate.Services;
+using System.Collections.ObjectModel;
+using Microsoft.Maui.Controls;
+
+namespace GymMate.ViewModels;
+
+public partial class CommentsViewModel : ObservableObject, IQueryAttributable
+{
+    private readonly IFeedService _service;
+    private readonly IFirebaseAuthService _auth;
+
+    public ObservableCollection<FeedComment> Comments { get; } = new();
+
+    [ObservableProperty]
+    private string postId = string.Empty;
+
+    [ObservableProperty]
+    private string text = string.Empty;
+
+    [ObservableProperty]
+    private bool isBusy;
+
+    public string CurrentUid => _auth.CurrentUserUid ?? string.Empty;
+
+    public CommentsViewModel(IFeedService service, IFirebaseAuthService auth)
+    {
+        _service = service;
+        _auth = auth;
+        _service.CommentsChanged += Service_CommentsChanged;
+    }
+
+    private async void Service_CommentsChanged(object? sender, string e)
+    {
+        if (e == PostId)
+            await LoadAsync();
+    }
+
+    public void ApplyQueryAttributes(IDictionary<string, object> query)
+    {
+        if (query.TryGetValue("postId", out var value) && value is string id)
+        {
+            PostId = id;
+        }
+    }
+
+    partial void OnPostIdChanged(string value)
+    {
+        if (!string.IsNullOrEmpty(value))
+            LoadAsync();
+    }
+
+    [RelayCommand]
+    private Task AppearingAsync()
+    {
+        return LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        IsBusy = true;
+        Comments.Clear();
+        await foreach (var c in _service.GetCommentsAsync(PostId))
+        {
+            c.IsMine = c.AuthorUid == _auth.CurrentUserUid;
+            Comments.Add(c);
+        }
+        IsBusy = false;
+    }
+
+    [RelayCommand]
+    private async Task SendAsync()
+    {
+        var uid = _auth.CurrentUserUid;
+        if (string.IsNullOrEmpty(uid) || string.IsNullOrWhiteSpace(Text)) return;
+        await _service.AddCommentAsync(PostId, Text.Trim(), uid);
+        Text = string.Empty;
+    }
+
+    [RelayCommand]
+    private async Task DeleteAsync(FeedComment comment)
+    {
+        var uid = _auth.CurrentUserUid;
+        if (comment == null || string.IsNullOrEmpty(uid)) return;
+        await _service.DeleteCommentAsync(PostId, comment.Id, uid);
+    }
+}

--- a/GymMate/GymMate/ViewModels/FeedViewModel.cs
+++ b/GymMate/GymMate/ViewModels/FeedViewModel.cs
@@ -93,4 +93,10 @@ public partial class FeedViewModel : ObservableObject
         else
             await _service.LikeAsync(post.Id, uid);
     }
+
+    [RelayCommand]
+    private async Task OpenCommentsAsync(string postId)
+    {
+        await Shell.Current.GoToAsync($"comments?postId={postId}");
+    }
 }

--- a/GymMate/GymMate/Views/CommentsPage.xaml
+++ b/GymMate/GymMate/Views/CommentsPage.xaml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:vm="clr-namespace:GymMate.ViewModels"
+             xmlns:models="clr-namespace:GymMate.Models"
+             x:Class="GymMate.Views.CommentsPage"
+             x:DataType="vm:CommentsViewModel"
+             x:Name="page">
+    <Grid RowDefinitions="*,Auto">
+        <CollectionView x:Name="commentsView"
+                        ItemsSource="{Binding Comments}">
+            <CollectionView.EmptyView>
+                <Label Text="Sé el primero en comentar" HorizontalOptions="Center" VerticalOptions="Center" />
+            </CollectionView.EmptyView>
+            <CollectionView.ItemTemplate>
+                <DataTemplate x:DataType="models:FeedComment">
+                    <SwipeView>
+                        <SwipeView.RightItems>
+                            <SwipeItems>
+                                <SwipeItem Text="Eliminar" BackgroundColor="Red"
+                                           IsVisible="{Binding IsMine}"
+                                           Command="{Binding Source={x:Reference page}, Path=BindingContext.DeleteCommand}"
+                                           CommandParameter="{Binding .}" />
+                            </SwipeItems>
+                        </SwipeView.RightItems>
+                        <Grid Padding="10">
+                            <Label Text="{Binding Text}" />
+                            <Label Text="{Binding CreatedUtc, StringFormat='{0:g}'}" FontSize="10" TextColor="Gray" />
+                        </Grid>
+                    </SwipeView>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+        <Grid Grid.Row="1" ColumnDefinitions="*,Auto" Padding="10">
+            <Editor Text="{Binding Text}" Placeholder="Escribe un comentario" AutoSize="TextChanges" />
+            <Button Grid.Column="1" Text="Enviar" Command="{Binding SendCommand}" />
+        </Grid>
+    </Grid>
+</ContentPage>

--- a/GymMate/GymMate/Views/CommentsPage.xaml.cs
+++ b/GymMate/GymMate/Views/CommentsPage.xaml.cs
@@ -1,0 +1,36 @@
+using GymMate.ViewModels;
+
+namespace GymMate.Views;
+
+public partial class CommentsPage : ContentPage
+{
+    public CommentsPage()
+    {
+        InitializeComponent();
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        if (BindingContext is GymMate.ViewModels.CommentsViewModel vm)
+            vm.AppearingCommand.Execute(null);
+    }
+
+    protected override void OnBindingContextChanged()
+    {
+        base.OnBindingContextChanged();
+        if (BindingContext is GymMate.ViewModels.CommentsViewModel vm)
+        {
+            vm.Comments.CollectionChanged += Comments_CollectionChanged;
+        }
+    }
+
+    private void Comments_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+    {
+        if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Add && e.NewItems != null)
+        {
+            var item = e.NewItems[e.NewItems.Count - 1];
+            commentsView.ScrollTo(item, ScrollToPosition.End, true);
+        }
+    }
+}

--- a/GymMate/GymMate/Views/FeedPage.xaml
+++ b/GymMate/GymMate/Views/FeedPage.xaml
@@ -24,6 +24,7 @@
                     <HorizontalStackLayout>
                         <Label Text="{Binding LikesCount}" />
                         <Button Text="❤️" Command="{Binding Source={x:Reference page}, Path=BindingContext.ToggleLikeCommand}" CommandParameter="{Binding .}" />
+                        <Button Text="💬 Comentarios" Command="{Binding Source={x:Reference page}, Path=BindingContext.OpenCommentsCommand}" CommandParameter="{Binding Id}" />
                     </HorizontalStackLayout>
                 </VerticalStackLayout>
             </DataTemplate>


### PR DESCRIPTION
## Summary
- allow posts to have comment threads
- list and manage comments from new CommentsPage
- navigate to CommentsPage from feed
- register comments route and services

## Testing
- `dotnet build -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f50aaa020832f9f17b0dfafc038ed