### PR TITLE
Create user profile after auth

### DIFF
--- a/GymMate/GymMate/MauiProgram.cs
+++ b/GymMate/GymMate/MauiProgram.cs
@@ -4,6 +4,7 @@ using Microsoft.Maui.Controls.Handlers.Items;
 using Plugin.Firebase;
 using Plugin.Firebase.CloudMessaging;
 using Plugin.LocalNotification;
+using Plugin.Firebase.Firestore;
 using Microcharts.Maui;
 using CommunityToolkit.Maui;
 using GymMate.Services;
@@ -34,7 +35,7 @@ namespace GymMate
                 handlers.AddHandler<CarouselView, CarouselViewHandler2>();
             });
 
-            builder.Services.AddSingleton<IFirebaseAuthService, FirebaseAuthService>();
+            builder.Services.AddSingleton<IFirebaseAuthService>(_ => new FirebaseAuthService(CrossFirebaseFirestore.Current));
             builder.Services.AddSingleton<IRealtimeDbService, RealtimeDbService>();
             builder.Services.AddSingleton<INotificationService, NotificationService>();
             builder.Services.AddSingleton<IClassBookingService, ClassBookingService>();

--- a/GymMate/GymMate/Models/UserProfile.cs
+++ b/GymMate/GymMate/Models/UserProfile.cs
@@ -2,8 +2,8 @@ namespace GymMate.Models;
 
 public class UserProfile
 {
-    public string? Id { get; set; }
-    public string? Email { get; set; }
+    public string Uid { get; set; } = string.Empty;
     public string DisplayName { get; set; } = string.Empty;
     public string? AvatarUrl { get; set; }
+    public DateTime CreatedUtc { get; set; } = DateTime.UtcNow;
 }

--- a/GymMate/GymMate/Services/FeedService.cs
+++ b/GymMate/GymMate/Services/FeedService.cs
@@ -64,7 +64,7 @@ public class FeedService : IFeedService
     {
         var uid = _auth.CurrentUserUid;
         if (string.IsNullOrEmpty(uid)) return Task.CompletedTask;
-        var profile = await _follow.GetProfileAsync(uid) ?? new UserProfile { Id = uid };
+        var profile = await _follow.GetProfileAsync(uid) ?? new UserProfile { Uid = uid };
         var post = new FeedPost
         {
             AuthorUid = uid,

--- a/GymMate/GymMate/Services/FirebaseAuthService.cs
+++ b/GymMate/GymMate/Services/FirebaseAuthService.cs
@@ -10,17 +10,44 @@ public interface IFirebaseAuthService
 
 public class FirebaseAuthService : IFirebaseAuthService
 {
-    public string CurrentUserUid { get; private set; } = "debug-user";
-    public Task<bool> LoginAsync(string email, string password)
+    private readonly IFirebaseFirestore _firestore;
+
+    public FirebaseAuthService(IFirebaseFirestore firestore)
     {
-        // TODO: Integrate Firebase Auth login
-        return Task.FromResult(true);
+        _firestore = firestore;
     }
 
-    public Task<bool> RegisterAsync(string email, string password)
+    public string CurrentUserUid { get; private set; } = "debug-user";
+
+    private async Task EnsureUserProfileAsync(string uid, string email)
+    {
+        var doc = _firestore.Document($"userProfiles/{uid}");
+        var snapshot = await doc.GetAsync();
+        if (!snapshot.Exists)
+        {
+            var profile = new Models.UserProfile
+            {
+                Uid = uid,
+                DisplayName = email.Split('@')[0],
+                AvatarUrl = string.Empty,
+                CreatedUtc = DateTime.UtcNow
+            };
+            await doc.SetAsync(profile);
+        }
+    }
+
+    public async Task<bool> LoginAsync(string email, string password)
+    {
+        // TODO: Integrate Firebase Auth login
+        await EnsureUserProfileAsync(CurrentUserUid, email);
+        return true;
+    }
+
+    public async Task<bool> RegisterAsync(string email, string password)
     {
         // TODO: Integrate Firebase Auth register
-        return Task.FromResult(true);
+        await EnsureUserProfileAsync(CurrentUserUid, email);
+        return true;
     }
 
     public Task LogoutAsync()

--- a/GymMate/GymMate/ViewModels/UserSearchViewModel.cs
+++ b/GymMate/GymMate/ViewModels/UserSearchViewModel.cs
@@ -56,14 +56,14 @@ public partial class UserSearchViewModel : ObservableObject
         Results.Clear();
         await foreach (var profile in _follow.SearchAsync(Query))
         {
-            if (profile.Id == uid) continue;
+            if (profile.Uid == uid) continue;
             var item = new UserSearchItem
             {
-                Id = profile.Id!,
+                Id = profile.Uid!,
                 DisplayName = profile.DisplayName,
                 AvatarUrl = profile.AvatarUrl,
-                IsFollowing = await _follow.IsFollowingAsync(profile.Id!),
-                IsFollower = followers.Contains(profile.Id!)
+                IsFollowing = await _follow.IsFollowingAsync(profile.Uid!),
+                IsFollower = followers.Contains(profile.Uid!)
             };
             Results.Add(item);
         }


### PR DESCRIPTION
## Summary
- add Uid/CreatedUtc fields to `UserProfile`
- ensure public profile exists after login and registration
- inject Firestore into `FirebaseAuthService`
- register `FirebaseAuthService` with Firestore instance
- update references to `UserProfile` Uid field

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet test GymMate/GymMate.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f58e7abc8832fbc50f8a02555b7bf