### PR TITLE
Implement user search feature

### DIFF
--- a/GymMate/GymMate/MauiProgram.cs
+++ b/GymMate/GymMate/MauiProgram.cs
@@ -35,6 +35,7 @@ namespace GymMate
                 handlers.AddHandler<CarouselView, CarouselViewHandler2>();
             });
 
+            builder.Services.AddSingleton<IFirebaseFirestore>(_ => CrossFirebaseFirestore.Current);
             builder.Services.AddSingleton<IFirebaseAuthService>(_ => new FirebaseAuthService(CrossFirebaseFirestore.Current));
             builder.Services.AddSingleton<IRealtimeDbService, RealtimeDbService>();
             builder.Services.AddSingleton<INotificationService, NotificationService>();

--- a/GymMate/GymMate/Views/HomePage.xaml
+++ b/GymMate/GymMate/Views/HomePage.xaml
@@ -3,7 +3,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="GymMate.Views.HomePage">
     <ContentPage.ToolbarItems>
-        <ToolbarItem Text="⚙️" Clicked="OnSettingsClicked" Priority="0" Order="Primary" />
+        <ToolbarItem Text="🔍 Usuarios" Clicked="OnUsersClicked" Priority="0" Order="Primary" />
+        <ToolbarItem Text="⚙️" Clicked="OnSettingsClicked" Priority="1" Order="Primary" />
     </ContentPage.ToolbarItems>
 
     <ScrollView>
@@ -56,10 +57,6 @@
             <Button
                 Text="Fotos"
                 Clicked="OnPhotosClicked"
-                HorizontalOptions="Fill" />
-            <Button
-                Text="🔍 Usuarios"
-                Clicked="OnUsersClicked"
                 HorizontalOptions="Fill" />
             <Button
                 Text="Feed"

--- a/GymMate/GymMate/Views/UserSearchPage.xaml
+++ b/GymMate/GymMate/Views/UserSearchPage.xaml
@@ -7,7 +7,7 @@
              x:DataType="vm:UserSearchViewModel"
              x:Name="page">
     <VerticalStackLayout>
-        <SearchBar Text="{Binding Query}" Placeholder="Buscar" />
+        <SearchBar Text="{Binding Query, Mode=TwoWay}" Placeholder="Buscar usuarios" />
         <CollectionView ItemsSource="{Binding Results}">
             <CollectionView.EmptyView>
                 <Label Text="Sin resultados" HorizontalOptions="Center" VerticalOptions="Center" />
@@ -22,7 +22,6 @@
                         </Image>
                         <VerticalStackLayout>
                             <Label Text="{Binding DisplayName}" />
-                            <Label Text="Seguir de vuelta" FontSize="12" TextColor="Green" IsVisible="{Binding IsFollower}" />
                         </VerticalStackLayout>
                         <Button Text="Seguir"
                                 Command="{Binding Source={x:Reference page}, Path=BindingContext.ToggleFollowCommand}" CommandParameter="{Binding .}">


### PR DESCRIPTION
## Summary
- register IFirebaseFirestore for DI
- refactor UserSearchViewModel to query Firestore directly and handle follows
- tweak UserSearchPage layout and placeholder
- use toolbar item on HomePage for user search navigation

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f5adefe34832f898b9dbd1b5a376a