### PR TITLE
Implement Profile Page with follow feature

### DIFF
--- a/GymMate/GymMate/ViewModels/FeedViewModel.cs
+++ b/GymMate/GymMate/ViewModels/FeedViewModel.cs
@@ -117,6 +117,6 @@ public partial class FeedViewModel : ObservableObject
     [RelayCommand]
     private async Task OpenProfileAsync(string uid)
     {
-        await Shell.Current.GoToAsync($"profile?uid={uid}");
+        await Shell.Current.GoToAsync($"profile?Uid={uid}");
     }
 }

--- a/GymMate/GymMate/ViewModels/ProfileViewModel.cs
+++ b/GymMate/GymMate/ViewModels/ProfileViewModel.cs
@@ -4,20 +4,20 @@ using GymMate.Models;
 using GymMate.Services;
 using System.Collections.ObjectModel;
 
+[QueryProperty(nameof(Uid), nameof(Uid))]
+
 namespace GymMate.ViewModels;
 
-public partial class ProfileViewModel : ObservableObject, IQueryAttributable
+public partial class ProfileViewModel : ObservableObject
 {
     private readonly IFollowService _follow;
     private readonly IProgressPhotoService _photos;
     private readonly IFirebaseAuthService _auth;
 
     [ObservableProperty] private string uid = string.Empty;
-    [ObservableProperty] private string displayName = string.Empty;
-    [ObservableProperty] private string? avatarUrl;
-    [ObservableProperty] private bool isMine;
+    [ObservableProperty] private UserProfile? profile;
+    [ObservableProperty] private bool isOwnProfile;
     [ObservableProperty] private bool isFollowing;
-    [ObservableProperty] private bool showFollowBack;
     [ObservableProperty] private int followersCount;
     [ObservableProperty] private int followingCount;
 
@@ -30,11 +30,6 @@ public partial class ProfileViewModel : ObservableObject, IQueryAttributable
         _auth = auth;
     }
 
-    public void ApplyQueryAttributes(IDictionary<string, object> query)
-    {
-        if (query.TryGetValue("uid", out var value) && value is string id)
-            Uid = id;
-    }
 
     partial void OnUidChanged(string value)
     {
@@ -52,25 +47,29 @@ public partial class ProfileViewModel : ObservableObject, IQueryAttributable
     private async Task LoadAsync()
     {
         var current = _auth.CurrentUserUid;
-        IsMine = Uid == current;
-        var profile = await _follow.GetProfileAsync(Uid);
-        if (profile != null)
-        {
-            DisplayName = profile.DisplayName;
-            AvatarUrl = profile.AvatarUrl;
-        }
+        IsOwnProfile = Uid == current;
+
+        Profile = await _follow.GetProfileAsync(Uid);
 
         var followers = new List<string>();
         await foreach (var f in _follow.GetFollowersAsync(Uid))
             followers.Add(f);
         FollowersCount = followers.Count;
-        ShowFollowBack = !IsMine && followers.Contains(current) && !await _follow.IsFollowingAsync(Uid);
 
         var following = new List<string>();
         await foreach (var f in _follow.GetFollowingAsync(Uid))
             following.Add(f);
         FollowingCount = following.Count;
-        IsFollowing = await _follow.IsFollowingAsync(Uid);
+
+        if (!IsOwnProfile)
+        {
+            var obs = await _follow.IsFollowingAsync(Uid);
+            IsFollowing = await obs.FirstAsync();
+        }
+        else
+        {
+            IsFollowing = false;
+        }
 
         Photos.Clear();
         await foreach (var p in _photos.GetPhotosAsync(Uid))
@@ -78,13 +77,20 @@ public partial class ProfileViewModel : ObservableObject, IQueryAttributable
     }
 
     [RelayCommand]
-    private async Task ToggleFollowAsync()
+    private async Task FollowOrUnfollowAsync()
     {
-        if (IsMine) return;
+        if (IsOwnProfile) return;
         if (IsFollowing)
+        {
+            IsFollowing = false;
+            FollowersCount = Math.Max(0, FollowersCount - 1);
             await _follow.UnfollowAsync(Uid);
+        }
         else
+        {
+            IsFollowing = true;
+            FollowersCount++;
             await _follow.FollowAsync(Uid);
-        await LoadAsync();
+        }
     }
 }

--- a/GymMate/GymMate/ViewModels/UserSearchViewModel.cs
+++ b/GymMate/GymMate/ViewModels/UserSearchViewModel.cs
@@ -88,6 +88,6 @@ public partial class UserSearchViewModel : ObservableObject
     [RelayCommand]
     private async Task OpenProfileAsync(string uid)
     {
-        await Shell.Current.GoToAsync($"profile?uid={uid}");
+        await Shell.Current.GoToAsync($"profile?Uid={uid}");
     }
 }

--- a/GymMate/GymMate/Views/ProfilePage.xaml
+++ b/GymMate/GymMate/Views/ProfilePage.xaml
@@ -9,27 +9,26 @@
              x:Name="page">
     <ScrollView>
         <VerticalStackLayout Padding="10" Spacing="10">
-            <HorizontalStackLayout Spacing="10" HorizontalOptions="Center">
-                <Image Source="{Binding AvatarUrl}" WidthRequest="80" HeightRequest="80" />
-                <VerticalStackLayout>
-                    <Label Text="{Binding DisplayName}" FontAttributes="Bold" />
-                    <Label Text="Seguir de vuelta" FontSize="12" TextColor="Green" IsVisible="{Binding ShowFollowBack}" />
-                </VerticalStackLayout>
+            <VerticalStackLayout Spacing="10" HorizontalOptions="Center">
+                <Border HeightRequest="120" WidthRequest="120" CornerRadius="60">
+                    <Image Source="{Binding Profile.AvatarUrl}" Aspect="AspectFill" />
+                </Border>
+                <Label Text="{Binding Profile.DisplayName}" FontAttributes="Bold" FontSize="24" HorizontalOptions="Center" />
+            </VerticalStackLayout>
+            <HorizontalStackLayout HorizontalOptions="Center" Spacing="20">
+                <Label Text="{Binding FollowersCount, StringFormat='{0} seguidores'}" />
+                <Label Text="{Binding FollowingCount, StringFormat='{0} siguiendo'}" />
             </HorizontalStackLayout>
-            <Button Text="Seguir" Command="{Binding ToggleFollowCommand}">
+            <Button Text="Seguir" Command="{Binding FollowOrUnfollowCommand}">
                 <Button.Triggers>
                     <DataTrigger TargetType="Button" Binding="{Binding IsFollowing}" Value="True">
                         <Setter Property="Text" Value="Dejar de seguir" />
                     </DataTrigger>
-                    <DataTrigger TargetType="Button" Binding="{Binding IsMine}" Value="True">
+                    <DataTrigger TargetType="Button" Binding="{Binding IsOwnProfile}" Value="True">
                         <Setter Property="IsVisible" Value="False" />
                     </DataTrigger>
                 </Button.Triggers>
             </Button>
-            <HorizontalStackLayout HorizontalOptions="Center">
-                <Label Text="{Binding FollowersCount} seguidores" Padding="5" />
-                <Label Text="{Binding FollowingCount} seguidos" Padding="5" />
-            </HorizontalStackLayout>
             <CollectionView ItemsSource="{Binding Photos}">
                 <CollectionView.ItemsLayout>
                     <GridItemsLayout Span="3" />

--- a/GymMate/GymMate/Views/ProfilePage.xaml.cs
+++ b/GymMate/GymMate/Views/ProfilePage.xaml.cs
@@ -1,9 +1,19 @@
+using GymMate.ViewModels;
+
 namespace GymMate.Views;
 
 public partial class ProfilePage : ContentPage
 {
-    public ProfilePage()
+    public ProfilePage(ProfileViewModel viewModel)
     {
         InitializeComponent();
+        BindingContext = viewModel;
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        if (BindingContext is ProfileViewModel vm)
+            vm.AppearingCommand.Execute(null);
     }
 }


### PR DESCRIPTION
## Summary
- implement follower service methods for profile information
- build ProfileViewModel using query parameter with follow/unfollow logic
- design ProfilePage with avatar, counts, follow button and progress photo grid
- navigate to ProfilePage from feed and user search

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f5d188508832f97ef8d25682bc4e6