### PR TITLE
Define Firestore rules for followers and feed

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,28 @@
+// Firestore security rules
+
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /userProfiles/{uid} {
+      allow read: if true;
+      allow write: if request.auth != null && request.auth.uid == uid;
+
+      match /followers/{followerUid} {
+        allow read: if true;
+        allow write, delete: if request.auth.uid == followerUid;
+      }
+      match /following/{followingUid} {
+        allow read: if true;
+        allow write, delete: if request.auth.uid == uid;
+      }
+    }
+
+    match /feedPosts/{postId} {
+      allow read: if true; // consultas whereIn + orderBy
+      allow write: if request.auth != null
+                   && request.resource.data.AuthorUid == request.auth.uid;
+    }
+  }
+}
+
+// Después de merge, ejecutar: firebase deploy --only firestore:indexes,firestore:rules


### PR DESCRIPTION
## Summary
- add `firestore.rules` with security rules for `userProfiles` and `feedPosts`
- note to run deployment command after merge

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684f60839944832fa0eeb25fe1da2994