### PR TITLE
Add Firebase Cloud Messaging integration

### DIFF
--- a/GymMate/GymMate/MauiProgram.cs
+++ b/GymMate/GymMate/MauiProgram.cs
@@ -36,9 +36,9 @@ namespace GymMate
             });
 
             builder.Services.AddSingleton<IFirebaseFirestore>(_ => CrossFirebaseFirestore.Current);
-            builder.Services.AddSingleton<IFirebaseAuthService>(_ => new FirebaseAuthService(CrossFirebaseFirestore.Current));
-            builder.Services.AddSingleton<IRealtimeDbService, RealtimeDbService>();
             builder.Services.AddSingleton<INotificationService, NotificationService>();
+            builder.Services.AddSingleton<IFirebaseAuthService, FirebaseAuthService>();
+            builder.Services.AddSingleton<IRealtimeDbService, RealtimeDbService>();
             builder.Services.AddSingleton<IClassBookingService, ClassBookingService>();
             builder.Services.AddSingleton<IProgressPhotoService, ProgressPhotoService>();
             builder.Services.AddSingleton<IFollowService, FollowService>();

--- a/GymMate/GymMate/Services/FirebaseAuthService.cs
+++ b/GymMate/GymMate/Services/FirebaseAuthService.cs
@@ -11,10 +11,12 @@ public interface IFirebaseAuthService
 public class FirebaseAuthService : IFirebaseAuthService
 {
     private readonly IFirebaseFirestore _firestore;
+    private readonly Lazy<INotificationService> _notificationService;
 
-    public FirebaseAuthService(IFirebaseFirestore firestore)
+    public FirebaseAuthService(IFirebaseFirestore firestore, Lazy<INotificationService> notificationService)
     {
         _firestore = firestore;
+        _notificationService = notificationService;
     }
 
     public string CurrentUserUid { get; private set; } = "debug-user";
@@ -40,6 +42,8 @@ public class FirebaseAuthService : IFirebaseAuthService
     {
         // TODO: Integrate Firebase Auth login
         await EnsureUserProfileAsync(CurrentUserUid, email);
+        await _notificationService.Value.InitialiseAsync();
+        await _notificationService.Value.SubscribeAsync($"user_{CurrentUserUid}");
         return true;
     }
 

--- a/GymMate/GymMate/ViewModels/SettingsViewModel.cs
+++ b/GymMate/GymMate/ViewModels/SettingsViewModel.cs
@@ -37,9 +37,9 @@ public partial class SettingsViewModel(INotificationService notifications) : Obs
     {
         Preferences.Set(nameof(NewRoutinesAlertsEnabled), value);
         if (value)
-            _notifications.SubscribeToTopicAsync("new-routines");
+            _notifications.SubscribeAsync("new-routines");
         else
-            _notifications.UnsubscribeFromTopicAsync("new-routines");
+            _notifications.UnsubscribeAsync("new-routines");
     }
 
     [RelayCommand]


### PR DESCRIPTION
## Summary
- integrate Firebase Cloud Messaging with NotificationService
- subscribe user topic and init notifications on login
- wire NotificationService and FirebaseAuthService via DI
- update SettingsViewModel to new notification methods

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f612cc6dc832f898373455b2f7248