### PR TITLE
Add settings page for notifications

### DIFF
--- a/GymMate/GymMate/Services/NotificationService.cs
+++ b/GymMate/GymMate/Services/NotificationService.cs
@@ -9,6 +9,7 @@ public interface INotificationService
     Task ScheduleLocalAsync(DateTime when, string title, string body, string id);
     Task SubscribeAsync(string topic);
     Task UnsubscribeAsync(string topic);
+    Task CancelLocalAsync(string id);
     Task InitialiseAsync();
 }
 
@@ -56,6 +57,12 @@ public class NotificationService : INotificationService
 
     public Task UnsubscribeAsync(string topic)
         => FirebaseMessaging.UnsubscribeFromTopic(topic);
+
+    public Task CancelLocalAsync(string id)
+    {
+        NotificationCenter.Current.Cancel(id.GetHashCode());
+        return Task.CompletedTask;
+    }
 
     public Task InitialiseAsync()
     {

--- a/GymMate/GymMate/Views/HomePage.xaml.cs
+++ b/GymMate/GymMate/Views/HomePage.xaml.cs
@@ -63,7 +63,7 @@
 
         private async void OnSettingsClicked(object? sender, EventArgs e)
         {
-            await Shell.Current.GoToAsync("settings");
+            await Shell.Current.GoToAsync("//settings");
         }
     }
 }

--- a/GymMate/GymMate/Views/SettingsPage.xaml
+++ b/GymMate/GymMate/Views/SettingsPage.xaml
@@ -6,13 +6,18 @@
              x:DataType="vm:SettingsViewModel">
     <VerticalStackLayout Padding="30" Spacing="20">
         <HorizontalStackLayout>
-            <Label Text="Recordatorios diarios" VerticalOptions="Center" />
-            <Switch IsToggled="{Binding DailyRemindersEnabled}" />
+            <Label Text="Notificaciones de nuevos posts"
+                   VerticalOptions="Center" />
+            <Switch IsToggled="{Binding IsFeedPushEnabled}" />
         </HorizontalStackLayout>
-        <TimePicker Time="{Binding DailyReminderTime}" />
         <HorizontalStackLayout>
-            <Label Text="Avisos de nuevas rutinas" VerticalOptions="Center" />
-            <Switch IsToggled="{Binding NewRoutinesAlertsEnabled}" />
+            <Label Text="Recordatorio diario de entrenamiento"
+                   VerticalOptions="Center" />
+            <Switch IsToggled="{Binding IsDailyReminderEnabled}" />
         </HorizontalStackLayout>
+        <TimePicker Time="{Binding ReminderTime}"
+                    Format="HH:mm"
+                    IsVisible="{Binding IsDailyReminderEnabled}" />
+        <Button Text="Guardar" Command="{Binding SaveCommand}" />
     </VerticalStackLayout>
 </ContentPage>

--- a/GymMate/GymMate/Views/SettingsPage.xaml.cs
+++ b/GymMate/GymMate/Views/SettingsPage.xaml.cs
@@ -8,6 +8,12 @@ public partial class SettingsPage : ContentPage
     {
         InitializeComponent();
         BindingContext = vm;
-        vm.Load();
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        if (BindingContext is SettingsViewModel vm)
+            vm.AppearingCommand.Execute(null);
     }
 }


### PR DESCRIPTION
## Summary
- implement notification cancellation in `NotificationService`
- rebuild `SettingsViewModel` with preferences load and save logic
- build UI for notification settings and load on appearing
- adjust home page settings navigation

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f62809ec0832f865bb3cfeb388e32