### PR TITLE
Implement offline routine caching

### DIFF
--- a/GymMate/GymMate/Data/LocalDbService.cs
+++ b/GymMate/GymMate/Data/LocalDbService.cs
@@ -19,6 +19,7 @@ public class LocalDbService
     {
         if (_initialized) return;
         await _db.CreateTableAsync<FeedPostDto>();
+        await _db.CreateTableAsync<WorkoutRoutineDto>();
         _initialized = true;
     }
 
@@ -56,5 +57,51 @@ public class LocalDbService
             UploadedUtc = d.UploadedUtc,
             LikesCount = d.LikesCount
         }).ToList();
+    }
+
+    public Task SaveRoutineAsync(WorkoutRoutine routine)
+        => SaveRoutineAsync(routine, false);
+
+    public async Task SaveRoutineAsync(WorkoutRoutine routine, bool pendingSync)
+    {
+        await InitAsync();
+        var dto = new WorkoutRoutineDto
+        {
+            Id = routine.Id,
+            Name = routine.Name,
+            Description = routine.Description,
+            CreatedUtc = routine.CreatedUtc.Ticks,
+            IsPendingSync = pendingSync
+        };
+        await _db.InsertOrReplaceAsync(dto);
+    }
+
+    public async Task DeleteRoutineAsync(string id)
+    {
+        await InitAsync();
+        await _db.DeleteAsync<WorkoutRoutineDto>(id);
+    }
+
+    public async Task<List<WorkoutRoutine>> GetCachedRoutinesAsync()
+    {
+        await InitAsync();
+        var dtos = await _db.Table<WorkoutRoutineDto>()
+            .OrderByDescending(x => x.CreatedUtc)
+            .ToListAsync();
+        return dtos.Select(d => new WorkoutRoutine
+        {
+            Id = d.Id,
+            Name = d.Name,
+            Description = d.Description,
+            CreatedUtc = new DateTime(d.CreatedUtc, DateTimeKind.Utc)
+        }).ToList();
+    }
+
+    public async Task<List<WorkoutRoutineDto>> GetPendingRoutineDtosAsync()
+    {
+        await InitAsync();
+        return await _db.Table<WorkoutRoutineDto>()
+            .Where(r => r.IsPendingSync)
+            .ToListAsync();
     }
 }

--- a/GymMate/GymMate/Data/WorkoutRoutineDto.cs
+++ b/GymMate/GymMate/Data/WorkoutRoutineDto.cs
@@ -1,0 +1,13 @@
+namespace GymMate.Data;
+
+using SQLite;
+
+public class WorkoutRoutineDto
+{
+    [PrimaryKey]
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public long CreatedUtc { get; set; }
+    public bool IsPendingSync { get; set; }
+}

--- a/GymMate/GymMate/Services/RoutinesService.cs
+++ b/GymMate/GymMate/Services/RoutinesService.cs
@@ -1,0 +1,100 @@
+namespace GymMate.Services;
+
+using GymMate.Models;
+using GymMate.Data;
+using Microsoft.Maui.Networking;
+using Plugin.Firebase.Firestore;
+
+public interface IRoutinesService
+{
+    Task<IEnumerable<WorkoutRoutine>> GetRoutinesAsync(string uid);
+    Task AddOrUpdateRoutineAsync(string uid, WorkoutRoutine routine);
+    Task DeleteRoutineAsync(string uid, string routineId);
+    Task SyncPendingAsync(string uid);
+    event EventHandler? RoutinesChanged;
+}
+
+public class RoutinesService : IRoutinesService
+{
+    private readonly IFirebaseFirestore _firestore;
+    private readonly LocalDbService _localDb;
+
+    public event EventHandler? RoutinesChanged;
+
+    public RoutinesService(IFirebaseFirestore firestore, LocalDbService localDb)
+    {
+        _firestore = firestore;
+        _localDb = localDb;
+    }
+
+    private CollectionReference GetCollection(string uid)
+        => _firestore.Collection($"userProfiles/{uid}/routines");
+
+    public async Task<IEnumerable<WorkoutRoutine>> GetRoutinesAsync(string uid)
+    {
+        if (!Connectivity.Current.IsConnected)
+            return await _localDb.GetCachedRoutinesAsync();
+
+        var snapshot = await GetCollection(uid).GetAsync();
+        var list = new List<WorkoutRoutine>();
+        foreach (var doc in snapshot.Documents)
+        {
+            var routine = doc.ToObject<WorkoutRoutine>();
+            if (routine != null)
+            {
+                routine.Id = doc.Id;
+                list.Add(routine);
+                await _localDb.SaveRoutineAsync(routine);
+            }
+        }
+        return list;
+    }
+
+    public async Task AddOrUpdateRoutineAsync(string uid, WorkoutRoutine routine)
+    {
+        if (!Connectivity.Current.IsConnected)
+        {
+            await _localDb.SaveRoutineAsync(routine, true);
+            RoutinesChanged?.Invoke(this, EventArgs.Empty);
+            return;
+        }
+
+        await GetCollection(uid).Document(routine.Id).SetAsync(routine);
+        await _localDb.SaveRoutineAsync(routine);
+        RoutinesChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    public async Task DeleteRoutineAsync(string uid, string routineId)
+    {
+        if (!Connectivity.Current.IsConnected)
+        {
+            await _localDb.DeleteRoutineAsync(routineId);
+            RoutinesChanged?.Invoke(this, EventArgs.Empty);
+            return;
+        }
+
+        await GetCollection(uid).Document(routineId).DeleteAsync();
+        await _localDb.DeleteRoutineAsync(routineId);
+        RoutinesChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    public async Task SyncPendingAsync(string uid)
+    {
+        if (!Connectivity.Current.IsConnected)
+            return;
+
+        var pending = await _localDb.GetPendingRoutineDtosAsync();
+        foreach (var dto in pending)
+        {
+            var routine = new WorkoutRoutine
+            {
+                Id = dto.Id,
+                Name = dto.Name,
+                Description = dto.Description,
+                CreatedUtc = new DateTime(dto.CreatedUtc, DateTimeKind.Utc)
+            };
+            await GetCollection(uid).Document(routine.Id).SetAsync(routine);
+            await _localDb.SaveRoutineAsync(routine);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add WorkoutRoutineDto for local database storage
- extend LocalDbService with workout routine table and CRUD helpers
- implement RoutinesService with offline support and sync
- register service and connectivity sync in MauiProgram

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f65687f74832f8d03dc21a0593101