### PR TITLE
Add Firebase analytics

### DIFF
--- a/GymMate/GymMate/App.xaml.cs
+++ b/GymMate/GymMate/App.xaml.cs
@@ -1,4 +1,6 @@
-﻿namespace GymMate
+using Plugin.Firebase.Crashlytics;
+
+namespace GymMate
 {
     public partial class App : Application
     {
@@ -14,7 +16,17 @@
 
         protected override Window CreateWindow(IActivationState? activationState)
         {
-            return new Window(new AppShell());
+            var shell = new AppShell();
+#if DEBUG
+            var grid = new Grid();
+            var crashBtn = new Button { IsVisible = false };
+            crashBtn.Clicked += async (s, e) => await FirebaseCrashlytics.DefaultInstance.CrashAsync();
+            grid.Children.Add(shell);
+            grid.Children.Add(crashBtn);
+            return new Window(grid);
+#else
+            return new Window(shell);
+#endif
         }
     }
 }

--- a/GymMate/GymMate/GymMate.csproj
+++ b/GymMate/GymMate/GymMate.csproj
@@ -73,6 +73,8 @@
                 <PackageReference Include="Plugin.Firebase.CloudMessaging" Version="3.1.1" />
                 <PackageReference Include="Microcharts.Maui" Version="0.9.5" />
                 <PackageReference Include="Plugin.Firebase.Firestore" Version="3.1.1" />
+                <PackageReference Include="Plugin.Firebase.Analytics" Version="3.1.1" />
+                <PackageReference Include="Plugin.Firebase.Crashlytics" Version="3.1.1" />
                 <PackageReference Include="CommunityToolkit.Maui" Version="8.2.0" />
                 <PackageReference Include="Plugin.Firebase.Storage" Version="3.1.1" />
                 <PackageReference Include="Maui.FFImageLoading" Version="2.4.11.982" />

--- a/GymMate/GymMate/MauiProgram.cs
+++ b/GymMate/GymMate/MauiProgram.cs
@@ -3,6 +3,8 @@ using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Handlers.Items;
 using Plugin.Firebase;
 using Plugin.Firebase.CloudMessaging;
+using Plugin.Firebase.Analytics;
+using Plugin.Firebase.Crashlytics;
 using Plugin.LocalNotification;
 using Plugin.Firebase.Firestore;
 using Microcharts.Maui;
@@ -23,6 +25,8 @@ namespace GymMate
                 .UseMauiApp<App>()
                 .UseFirebaseApp()
                 .UseFirebaseCloudMessaging()
+                .UseFirebaseAnalytics()
+                .UseFirebaseCrashlytics()
                 .UseLocalNotification()
                 .UseMicrocharts()
                 .UseMauiCommunityToolkit()
@@ -49,6 +53,7 @@ namespace GymMate
             builder.Services.AddSingleton<IProgressPhotoService, ProgressPhotoService>();
             builder.Services.AddSingleton<IFollowService, FollowService>();
             builder.Services.AddSingleton<LocalDbService>();
+            builder.Services.AddSingleton<IAnalyticsService, AnalyticsService>();
             builder.Services.AddSingleton<IFeedService, FeedService>();
             builder.Services.AddTransient<ViewModels.RestTimerViewModel>();
             builder.Services.AddTransient<Views.RestTimerPage>();

--- a/GymMate/GymMate/Platforms/iOS/Info.plist
+++ b/GymMate/GymMate/Platforms/iOS/Info.plist
@@ -26,7 +26,11 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>XSAppIconAssets</key>
-	<string>Assets.xcassets/appicon.appiconset</string>
+        <key>XSAppIconAssets</key>
+        <string>Assets.xcassets/appicon.appiconset</string>
+        <key>FirebaseCrashlyticsCollectionEnabled</key>
+        <true/>
+        <key>FirebaseAnalyticsCollectionEnabled</key>
+        <true/>
 </dict>
 </plist>

--- a/GymMate/GymMate/Services/AnalyticsService.cs
+++ b/GymMate/GymMate/Services/AnalyticsService.cs
@@ -1,0 +1,17 @@
+using Plugin.Firebase.Analytics;
+
+namespace GymMate.Services;
+
+public interface IAnalyticsService
+{
+    Task LogEventAsync(string name, IDictionary<string, object>? parameters = null);
+    Task SetUserIdAsync(string uid);
+}
+
+class AnalyticsService : IAnalyticsService
+{
+    readonly IFirebaseAnalytics _fa = CrossFirebaseAnalytics.Current;
+    public Task LogEventAsync(string n, IDictionary<string, object>? p = null)
+        => _fa.LogEventAsync(n, p);
+    public Task SetUserIdAsync(string uid) => _fa.SetUserIdAsync(uid);
+}

--- a/GymMate/GymMate/Services/FeedService.cs
+++ b/GymMate/GymMate/Services/FeedService.cs
@@ -27,16 +27,18 @@ public class FeedService : IFeedService
     private readonly INotificationService _notifications;
     private readonly IFollowService _follow;
     private readonly LocalDbService _localDb;
+    private readonly IAnalyticsService _analytics;
 
     public event EventHandler<FeedPost>? PostUpdated;
     public event EventHandler<string>? CommentsChanged;
 
-    public FeedService(IFirebaseAuthService auth, INotificationService notifications, IFollowService follow, LocalDbService localDb)
+    public FeedService(IFirebaseAuthService auth, INotificationService notifications, IFollowService follow, LocalDbService localDb, IAnalyticsService analytics)
     {
         _auth = auth;
         _notifications = notifications;
         _follow = follow;
         _localDb = localDb;
+        _analytics = analytics;
     }
 
     public async IAsyncEnumerable<FeedPost> GetLatestAsync(int pageSize = 20, DateTime? startAfter = null)
@@ -118,7 +120,7 @@ public class FeedService : IFeedService
             post.LikesCount = set.Count;
             PostUpdated?.Invoke(this, post);
         }
-        return Task.CompletedTask;
+        return _analytics.LogEventAsync("post_like");
     }
 
     public Task UnlikeAsync(string postId, string uid)
@@ -130,7 +132,7 @@ public class FeedService : IFeedService
             post.LikesCount = set.Count;
             PostUpdated?.Invoke(this, post);
         }
-        return Task.CompletedTask;
+        return _analytics.LogEventAsync("post_like");
     }
 
     public Task<bool> IsLikedAsync(string postId, string uid)

--- a/GymMate/GymMate/Services/FirebaseAuthService.cs
+++ b/GymMate/GymMate/Services/FirebaseAuthService.cs
@@ -12,11 +12,13 @@ public class FirebaseAuthService : IFirebaseAuthService
 {
     private readonly IFirebaseFirestore _firestore;
     private readonly Lazy<INotificationService> _notificationService;
+    private readonly IAnalyticsService _analytics;
 
-    public FirebaseAuthService(IFirebaseFirestore firestore, Lazy<INotificationService> notificationService)
+    public FirebaseAuthService(IFirebaseFirestore firestore, Lazy<INotificationService> notificationService, IAnalyticsService analytics)
     {
         _firestore = firestore;
         _notificationService = notificationService;
+        _analytics = analytics;
     }
 
     public string CurrentUserUid { get; private set; } = "debug-user";
@@ -44,6 +46,8 @@ public class FirebaseAuthService : IFirebaseAuthService
         await EnsureUserProfileAsync(CurrentUserUid, email);
         await _notificationService.Value.InitialiseAsync();
         await _notificationService.Value.SubscribeAsync($"user_{CurrentUserUid}");
+        await _analytics.SetUserIdAsync(CurrentUserUid);
+        await _analytics.LogEventAsync("login_success");
         return true;
     }
 
@@ -51,6 +55,8 @@ public class FirebaseAuthService : IFirebaseAuthService
     {
         // TODO: Integrate Firebase Auth register
         await EnsureUserProfileAsync(CurrentUserUid, email);
+        await _analytics.SetUserIdAsync(CurrentUserUid);
+        await _analytics.LogEventAsync("login_success");
         return true;
     }
 

--- a/GymMate/GymMate/Services/FollowService.cs
+++ b/GymMate/GymMate/Services/FollowService.cs
@@ -19,10 +19,12 @@ public class FollowService : IFollowService
 {
     private readonly IFirebaseAuthService _auth;
     private readonly IFirebaseFirestore _firestore = CrossFirebaseFirestore.Current;
+    private readonly IAnalyticsService _analytics;
 
-    public FollowService(IFirebaseAuthService auth)
+    public FollowService(IFirebaseAuthService auth, IAnalyticsService analytics)
     {
         _auth = auth;
+        _analytics = analytics;
     }
 
     public async Task FollowAsync(string targetUid)
@@ -37,6 +39,7 @@ public class FollowService : IFollowService
             transaction.Set(followingDoc, new { });
             transaction.Set(followerDoc, new { });
         });
+        await _analytics.LogEventAsync("follow_user");
     }
 
     public async Task UnfollowAsync(string targetUid)
@@ -51,6 +54,7 @@ public class FollowService : IFollowService
             transaction.Delete(followingDoc);
             transaction.Delete(followerDoc);
         });
+        await _analytics.LogEventAsync("follow_user");
     }
 
     public async IAsyncEnumerable<string> GetFollowingAsync(string uid)

--- a/GymMate/GymMate/ViewModels/SettingsViewModel.cs
+++ b/GymMate/GymMate/ViewModels/SettingsViewModel.cs
@@ -6,11 +6,12 @@ using GymMate.Services;
 
 namespace GymMate.ViewModels;
 
-public partial class SettingsViewModel(INotificationService notifications, IFirebaseAuthService auth, IPreferences preferences) : ObservableObject
+public partial class SettingsViewModel(INotificationService notifications, IFirebaseAuthService auth, IPreferences preferences, IAnalyticsService analytics) : ObservableObject
 {
     private readonly INotificationService _notifications = notifications;
     private readonly IFirebaseAuthService _auth = auth;
     private readonly IPreferences _preferences = preferences;
+    private readonly IAnalyticsService _analytics = analytics;
 
     [ObservableProperty]
     private bool isFeedPushEnabled;
@@ -57,6 +58,7 @@ public partial class SettingsViewModel(INotificationService notifications, IFire
             await _notifications.CancelLocalAsync("daily_reminder");
         }
 
+        await _analytics.LogEventAsync("settings_saved");
         await Toast.Make("Ajustes guardados").Show();
     }
 }


### PR DESCRIPTION
## Summary
- add Firebase analytics and crashlytics packages
- enable UseFirebaseAnalytics and UseFirebaseCrashlytics
- implement AnalyticsService and register it
- log analytics events in services
- add optional debug crash button
- enable iOS collection keys

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684f6bda5594832fb60a55b51dab9946