### PR TITLE
Implement new feed cards UI

### DIFF
--- a/GymMate/GymMate/Resources/Styles/Controls.xaml
+++ b/GymMate/GymMate/Resources/Styles/Controls.xaml
@@ -16,6 +16,18 @@
         <Setter Property="TextColor" Value="{DynamicResource TextColor}" />
         <Setter Property="HorizontalTextAlignment" Value="Center" />
     </Style>
+    <Style x:Key="subtitle" TargetType="Label">
+        <Setter Property="FontSize" Value="18" />
+        <Setter Property="TextColor" Value="{DynamicResource TextColor}" />
+    </Style>
+    <Style x:Key="body" TargetType="Label">
+        <Setter Property="FontSize" Value="14" />
+        <Setter Property="TextColor" Value="{DynamicResource TextColor}" />
+    </Style>
+    <Style x:Key="caption" TargetType="Label">
+        <Setter Property="FontSize" Value="12" />
+        <Setter Property="TextColor" Value="{DynamicResource TextColor}" />
+    </Style>
     <Style TargetType="Button">
         <Setter Property="TextColor" Value="{DynamicResource TextColor}" />
         <Setter Property="BackgroundColor" Value="{DynamicResource PrimaryColor}" />

--- a/GymMate/GymMate/Resources/Themes/Colors.xaml
+++ b/GymMate/GymMate/Resources/Themes/Colors.xaml
@@ -9,6 +9,7 @@
         <Color x:Key="AccentColor">#FFFFC107</Color>
         <Color x:Key="AccentGradientStart">#FF4CAF50</Color>
         <Color x:Key="AccentGradientEnd">#FFFFC107</Color>
+        <Color x:Key="CardColor">#F2FFFFFF</Color>
     </ResourceDictionary>
     <ResourceDictionary x:Class="GymMate.Resources.Themes.DarkColors">
         <Color x:Key="PrimaryColor">#FF4CAF50</Color>
@@ -18,5 +19,6 @@
         <Color x:Key="AccentColor">#FFFFC107</Color>
         <Color x:Key="AccentGradientStart">#FF4CAF50</Color>
         <Color x:Key="AccentGradientEnd">#FFFFC107</Color>
+        <Color x:Key="CardColor">#F2000000</Color>
     </ResourceDictionary>
 </ResourceDictionary>

--- a/GymMate/GymMate/ViewModels/FeedPostVm.cs
+++ b/GymMate/GymMate/ViewModels/FeedPostVm.cs
@@ -1,0 +1,26 @@
+using System.Windows.Input;
+
+namespace GymMate.ViewModels;
+
+public class FeedPostVm
+{
+    public string? AuthorAvatarUrl { get; set; }
+    public string AuthorName { get; set; } = string.Empty;
+    public string PhotoUrl { get; set; } = string.Empty;
+    public string? Caption { get; set; }
+    public int LikesCount { get; set; }
+    public ICommand LikeCommand { get; }
+    public ICommand CommentCommand { get; }
+
+    public FeedPostVm(string? avatarUrl, string authorName, string photoUrl, string? caption,
+        int likes, ICommand likeCmd, ICommand commentCmd)
+    {
+        AuthorAvatarUrl = avatarUrl;
+        AuthorName = authorName;
+        PhotoUrl = photoUrl;
+        Caption = caption;
+        LikesCount = likes;
+        LikeCommand = likeCmd;
+        CommentCommand = commentCmd;
+    }
+}

--- a/GymMate/GymMate/ViewModels/FeedViewModel.cs
+++ b/GymMate/GymMate/ViewModels/FeedViewModel.cs
@@ -1,8 +1,10 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using GymMate.Models;
+using System.Windows.Input;
 using GymMate.Services;
 using System.Collections.ObjectModel;
+using System.Collections.Generic;
 
 namespace GymMate.ViewModels;
 
@@ -12,7 +14,9 @@ public partial class FeedViewModel : ObservableObject
     private readonly IFirebaseAuthService _auth;
     private readonly IFollowService _follow;
 
-    public ObservableCollection<FeedPost> Posts { get; } = new();
+    public ObservableCollection<FeedPostVm> Posts { get; } = new();
+
+    private readonly Dictionary<string, FeedPostVm> _map = new();
 
     private DateTime? _lastDate;
 
@@ -40,16 +44,18 @@ public partial class FeedViewModel : ObservableObject
     {
         MainThread.BeginInvokeOnMainThread(() =>
         {
-            var existing = Posts.FirstOrDefault(p => p.Id == e.Id);
-            if (existing == null)
+            var vm = ToVm(e);
+            if (_map.TryGetValue(e.Id, out var existing))
             {
-                Posts.Insert(0, e);
+                var index = Posts.IndexOf(existing);
+                if (index >= 0)
+                    Posts[index] = vm;
             }
             else
             {
-                var index = Posts.IndexOf(existing);
-                Posts[index] = e;
+                Posts.Insert(0, vm);
             }
+            _map[e.Id] = vm;
         });
     }
 
@@ -65,6 +71,7 @@ public partial class FeedViewModel : ObservableObject
     {
         IsRefreshing = true;
         Posts.Clear();
+        _map.Clear();
         _lastDate = null;
         await LoadMoreAsync();
         IsRefreshing = false;
@@ -94,7 +101,11 @@ public partial class FeedViewModel : ObservableObject
         if (list.Count > 0)
             _lastDate = list.Last().UploadedUtc;
         foreach (var p in list)
-            Posts.Add(p);
+        {
+            var vm = ToVm(p);
+            Posts.Add(vm);
+            _map[p.Id] = vm;
+        }
 
         IsEmpty = Posts.Count == 0;
         if (IsEmpty)
@@ -122,6 +133,14 @@ public partial class FeedViewModel : ObservableObject
             await _service.UnlikeAsync(post.Id, uid);
         else
             await _service.LikeAsync(post.Id, uid);
+    }
+
+    private FeedPostVm ToVm(FeedPost post)
+    {
+        ICommand likeCmd = new AsyncRelayCommand(() => ToggleLikeAsync(post));
+        ICommand commentCmd = new AsyncRelayCommand(() => OpenCommentsAsync(post.Id));
+        return new FeedPostVm(post.AuthorAvatarUrl, post.AuthorName, post.PhotoUrl,
+            post.Caption, post.LikesCount, likeCmd, commentCmd);
     }
 
     [RelayCommand]

--- a/GymMate/GymMate/Views/FeedPage.xaml
+++ b/GymMate/GymMate/Views/FeedPage.xaml
@@ -2,47 +2,42 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:vm="clr-namespace:GymMate.ViewModels"
-             xmlns:models="clr-namespace:GymMate.Models"
-             xmlns:ff="clr-namespace:FFImageLoading.Maui;assembly=Maui.FFImageLoading"
              x:Class="GymMate.Views.FeedPage"
              x:DataType="vm:FeedViewModel"
              x:Name="page">
-    <Grid>
-        <CollectionView ItemsSource="{Binding Posts}"
-                        RemainingItemsThreshold="5"
-                        RemainingItemsThresholdReachedCommand="{Binding LoadMoreCommand}"
-                        IsPullToRefreshEnabled="True"
-                        IsRefreshing="{Binding IsRefreshing}"
-                        RefreshCommand="{Binding RefreshCommand}">
-            <CollectionView.ItemTemplate>
-                <DataTemplate x:DataType="models:FeedPost">
-                    <VerticalStackLayout Padding="10" Spacing="5">
-                    <HorizontalStackLayout Spacing="10">
-                        <Image Source="{Binding AuthorAvatarUrl}" WidthRequest="32" HeightRequest="32">
-                            <Image.GestureRecognizers>
-                                <TapGestureRecognizer Command="{Binding Source={x:Reference page}, Path=BindingContext.OpenProfileCommand}" CommandParameter="{Binding AuthorUid}" />
-                            </Image.GestureRecognizers>
-                        </Image>
-                        <Label Text="{Binding AuthorName}" VerticalOptions="Center">
-                            <Label.GestureRecognizers>
-                                <TapGestureRecognizer Command="{Binding Source={x:Reference page}, Path=BindingContext.OpenProfileCommand}" CommandParameter="{Binding AuthorUid}" />
-                            </Label.GestureRecognizers>
-                        </Label>
-                    </HorizontalStackLayout>
-                    <ff:CachedImage Source="{Binding PhotoUrl}" Aspect="AspectFill" HeightRequest="300" />
-                    <Label Text="{Binding Caption}" />
-                    <HorizontalStackLayout>
-                        <Label Text="{Binding LikesCount}" />
-                        <Button Text="❤️" Command="{Binding Source={x:Reference page}, Path=BindingContext.ToggleLikeCommand}" CommandParameter="{Binding .}" />
-                        <Button Text="{DynamicResource Comments}" Command="{Binding Source={x:Reference page}, Path=BindingContext.OpenCommentsCommand}" CommandParameter="{Binding Id}" />
-                    </HorizontalStackLayout>
-                </VerticalStackLayout>
+    <CollectionView x:Name="PostsCollection"
+                    ItemsSource="{Binding Posts}"
+                    RemainingItemsThreshold="5"
+                    RemainingItemsThresholdReachedCommand="{Binding LoadMoreCommand}"
+                    IsPullToRefreshEnabled="True"
+                    IsRefreshing="{Binding IsRefreshing}"
+                    RefreshCommand="{Binding RefreshCommand}"
+                    VerticalScrollBarVisibility="Never">
+        <CollectionView.Header>
+            <Grid Padding="16,0" BackgroundColor="{DynamicResource BackgroundColor}">
+                <Label Text="{DynamicResource Feed}" Style="{DynamicResource h1}" />
+            </Grid>
+        </CollectionView.Header>
+        <CollectionView.ItemTemplate>
+            <DataTemplate x:DataType="vm:FeedPostVm">
+                <Frame CornerRadius="12" Margin="16,8" HasShadow="False" BackgroundColor="{DynamicResource CardColor}">
+                    <VerticalStackLayout Spacing="8">
+                        <HorizontalStackLayout Padding="8,4">
+                            <Image Source="{Binding AuthorAvatarUrl}" HeightRequest="40" WidthRequest="40" Aspect="AspectFill" ClipToBounds="True" CornerRadius="20" />
+                            <Label Text="{Binding AuthorName}" VerticalOptions="Center" Margin="8,0" Style="{DynamicResource subtitle}" />
+                        </HorizontalStackLayout>
+                        <Image Source="{Binding PhotoUrl}" Aspect="AspectFill" HeightRequest="250" CornerRadius="8" />
+                        <VerticalStackLayout Padding="8,4" Spacing="4">
+                            <Label Text="{Binding Caption}" Style="{DynamicResource body}" />
+                            <HorizontalStackLayout Spacing="24">
+                                <Button Text="&#xe87d;" FontFamily="MaterialIcons" FontSize="24" Command="{Binding LikeCommand}" />
+                                <Button Text="&#xe0b7;" FontFamily="MaterialIcons" FontSize="24" Command="{Binding CommentCommand}" />
+                            </HorizontalStackLayout>
+                            <Label Text="{Binding LikesCount, StringFormat='{0} likes'}" Style="{DynamicResource caption}" Opacity="0.7" />
+                        </VerticalStackLayout>
+                    </VerticalStackLayout>
+                </Frame>
             </DataTemplate>
         </CollectionView.ItemTemplate>
-        </CollectionView>
-        <Label Text="{Binding EmptyMessage}"
-               IsVisible="{Binding IsEmpty}"
-               HorizontalOptions="Center"
-               VerticalOptions="Center" />
-    </Grid>
+    </CollectionView>
 </ContentPage>

--- a/GymMate/GymMate/Views/FeedPage.xaml.cs
+++ b/GymMate/GymMate/Views/FeedPage.xaml.cs
@@ -1,3 +1,6 @@
+using GymMate.ViewModels;
+using System.Threading.Tasks;
+
 namespace GymMate.Views;
 
 public partial class FeedPage : ContentPage
@@ -5,5 +8,29 @@ public partial class FeedPage : ContentPage
     public FeedPage()
     {
         InitializeComponent();
+    }
+
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+        if (BindingContext is GymMate.ViewModels.FeedViewModel vm)
+            await vm.AppearingAsync();
+
+        foreach (var element in PostsCollection.VisibleViews)
+        {
+            if (element is VisualElement ve)
+            {
+                ve.TranslationY = 60;
+                ve.Opacity = 0;
+            }
+        }
+
+        await Task.Delay(100);
+
+        foreach (var element in PostsCollection.VisibleViews)
+        {
+            if (element is VisualElement ve)
+                await Task.WhenAll(ve.TranslateTo(0, 0, 300), ve.FadeTo(1, 300));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- redesign the feed using card-like posts
- add FeedPostVm for UI binding
- adapt FeedViewModel to project posts and handle updates
- add feed card animations on appearing
- extend label styles and card color resources

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f76a1d104832f9cc6b40f87781735