### PR TITLE
Modern onboarding screens

### DIFF
--- a/GymMate/GymMate/AppShell.xaml
+++ b/GymMate/GymMate/AppShell.xaml
@@ -5,10 +5,9 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:local="clr-namespace:GymMate.Views"
     Title="GymMate">
-    <ShellContent
-        Title="{DynamicResource Login}"
-        ContentTemplate="{DataTemplate local:LoginPage}"
-        Route="Login" />
+    <FlyoutItem Title="{DynamicResource Login}" Route="login" IsVisible="False">
+        <ShellContent ContentTemplate="{DataTemplate local:LoginPage}" />
+    </FlyoutItem>
     <FlyoutItem
         Title="{DynamicResource Home}">
         <FlyoutItem.Icon>

--- a/GymMate/GymMate/AppShell.xaml.cs
+++ b/GymMate/GymMate/AppShell.xaml.cs
@@ -5,6 +5,8 @@
         public AppShell()
         {
             InitializeComponent();
+            Routing.RegisterRoute("login", typeof(Views.LoginPage));
+            Routing.RegisterRoute("register", typeof(Views.RegisterPage));
             Routing.RegisterRoute("resttimer", typeof(Views.RestTimerPage));
             Routing.RegisterRoute("routines", typeof(Views.RoutinesPage));
             Routing.RegisterRoute("routineDetail", typeof(Views.RoutineDetailPage));

--- a/GymMate/GymMate/GymMate.csproj
+++ b/GymMate/GymMate/GymMate.csproj
@@ -49,8 +49,9 @@
 		<MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#512BD4" BaseSize="128,128" />
 
 		<!-- Images -->
-		<MauiImage Include="Resources\Images\*" />
-		<MauiImage Update="Resources\Images\logo.png" Resize="True" BaseSize="300,185" />
+                <MauiImage Include="Resources\Images\*" />
+                <MauiImage Update="Resources\Images\logo.png" Resize="True" BaseSize="300,185" />
+                <!-- TODO: copiar bg_gym.jpg en Resources/Images -->
 
                 <!-- Custom Fonts -->
                 <MauiFont Include="Resources\Fonts\*" />

--- a/GymMate/GymMate/Resources/Strings/Strings.en.xaml
+++ b/GymMate/GymMate/Resources/Strings/Strings.en.xaml
@@ -46,4 +46,7 @@
     <sys:String x:Key="HelloWorld">Hello, World!</sys:String>
     <sys:String x:Key="Welcome">Welcome to &#10;.NET Multi-platform App UI</sys:String>
     <sys:String x:Key="ClickMe">Click me</sys:String>
+    <sys:String x:Key="Tagline">Work out smarter</sys:String>
+    <sys:String x:Key="Back">Back</sys:String>
+    <sys:String x:Key="ConfirmPassword">Confirm password</sys:String>
 </ResourceDictionary>

--- a/GymMate/GymMate/Resources/Strings/Strings.es.xaml
+++ b/GymMate/GymMate/Resources/Strings/Strings.es.xaml
@@ -46,4 +46,7 @@
     <sys:String x:Key="HelloWorld">Hola Mundo</sys:String>
     <sys:String x:Key="Welcome">Bienvenido a &#10;.NET Multi-platform App UI</sys:String>
     <sys:String x:Key="ClickMe">Púlsame</sys:String>
+    <sys:String x:Key="Tagline">Entrena con estilo</sys:String>
+    <sys:String x:Key="Back">Volver</sys:String>
+    <sys:String x:Key="ConfirmPassword">Confirmar contraseña</sys:String>
 </ResourceDictionary>

--- a/GymMate/GymMate/Resources/Styles/Controls.xaml
+++ b/GymMate/GymMate/Resources/Styles/Controls.xaml
@@ -40,4 +40,25 @@
         <Setter Property="BackgroundColor" Value="{DynamicResource BackgroundColor}" />
         <Setter Property="BorderColor" Value="{DynamicResource SecondaryColor}" />
     </Style>
+
+    <Style x:Key="entryIcon" TargetType="Entry">
+        <Setter Property="BackgroundColor" Value="#FFFFFFDD" />
+        <Setter Property="CornerRadius" Value="12" />
+        <Setter Property="Margin" Value="0,8" />
+        <Setter Property="Padding" Value="40,12,12,12" />
+        <Setter Property="FontImageSource.FontFamily" Value="MaterialIcons" />
+        <Setter Property="FontImageSource.Color" Value="{DynamicResource AccentColor}" />
+    </Style>
+
+    <Style x:Key="primaryButton" TargetType="Button">
+        <Setter Property="TextColor" Value="White" />
+        <Setter Property="BackgroundColor" Value="{DynamicResource PrimaryColor}" />
+        <Setter Property="CornerRadius" Value="24" />
+        <Setter Property="HeightRequest" Value="48" />
+    </Style>
+
+    <Style x:Key="linkButton" TargetType="Button">
+        <Setter Property="BackgroundColor" Value="Transparent" />
+        <Setter Property="TextColor" Value="{DynamicResource PrimaryColor}" />
+    </Style>
 </ResourceDictionary>

--- a/GymMate/GymMate/ViewModels/LoginViewModel.cs
+++ b/GymMate/GymMate/ViewModels/LoginViewModel.cs
@@ -1,4 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Maui.Alerts;
 
 namespace GymMate.ViewModels;
 
@@ -9,4 +11,19 @@ public partial class LoginViewModel : ObservableObject
 
     [ObservableProperty]
     private string password = string.Empty;
+
+    [RelayCommand]
+    private async Task NavigateRegisterAsync()
+        => await Shell.Current.GoToAsync("//register");
+
+    [RelayCommand]
+    private async Task LoginAsync()
+    {
+        if (string.IsNullOrWhiteSpace(Email) || string.IsNullOrWhiteSpace(Password))
+        {
+            await Toast.Make("Email/Password required").Show();
+            return;
+        }
+        // TODO: call auth service
+    }
 }

--- a/GymMate/GymMate/ViewModels/RegisterViewModel.cs
+++ b/GymMate/GymMate/ViewModels/RegisterViewModel.cs
@@ -1,0 +1,39 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Maui.Alerts;
+
+namespace GymMate.ViewModels;
+
+public partial class RegisterViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private string email = string.Empty;
+
+    [ObservableProperty]
+    private string password = string.Empty;
+
+    [ObservableProperty]
+    private string confirmPassword = string.Empty;
+
+    [RelayCommand]
+    private async Task NavigateBackAsync()
+        => await Shell.Current.GoToAsync("..");
+
+    [RelayCommand]
+    private async Task RegisterAsync()
+    {
+        if (string.IsNullOrWhiteSpace(Email) ||
+            string.IsNullOrWhiteSpace(Password) ||
+            string.IsNullOrWhiteSpace(ConfirmPassword))
+        {
+            await Toast.Make("Complete all fields").Show();
+            return;
+        }
+        if (Password != ConfirmPassword)
+        {
+            await Toast.Make("Passwords do not match").Show();
+            return;
+        }
+        // TODO: call auth service
+    }
+}

--- a/GymMate/GymMate/Views/LoginPage.xaml.cs
+++ b/GymMate/GymMate/Views/LoginPage.xaml.cs
@@ -6,4 +6,11 @@ public partial class LoginPage : ContentPage
     {
         InitializeComponent();
     }
+
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+        Content.Opacity = 0;
+        await Content.FadeTo(1, 400, Easing.SinOut);
+    }
 }

--- a/GymMate/GymMate/Views/RegisterPage.xaml
+++ b/GymMate/GymMate/Views/RegisterPage.xaml
@@ -2,7 +2,7 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
-             x:Class="GymMate.Views.LoginPage">
+             x:Class="GymMate.Views.RegisterPage">
     <Grid>
         <!-- TODO: copy bg_gym.jpg into Resources/Images -->
         <Image Source="bg_gym.jpg" Aspect="AspectFill">
@@ -24,9 +24,14 @@
                         <FontImageSource Glyph="&#xe897;" />
                     </Entry.FontImageSource>
                 </Entry>
-                <Button Text="{DynamicResource Login}" Style="{DynamicResource primaryButton}" />
+                <Entry Style="{DynamicResource entryIcon}" Placeholder="{DynamicResource ConfirmPassword}" IsPassword="True">
+                    <Entry.FontImageSource>
+                        <FontImageSource Glyph="&#xe897;" />
+                    </Entry.FontImageSource>
+                </Entry>
+                <Button Text="{DynamicResource Register}" Style="{DynamicResource primaryButton}" />
             </Frame>
-            <Button Text="{DynamicResource Register}" Style="{DynamicResource linkButton}" Command="{Binding NavigateRegisterCommand}" />
+            <Button Text="{DynamicResource Back}" Style="{DynamicResource linkButton}" Command="{Binding NavigateBackCommand}" />
         </VerticalStackLayout>
     </Grid>
 </ContentPage>

--- a/GymMate/GymMate/Views/RegisterPage.xaml.cs
+++ b/GymMate/GymMate/Views/RegisterPage.xaml.cs
@@ -1,0 +1,9 @@
+namespace GymMate.Views;
+
+public partial class RegisterPage : ContentPage
+{
+    public RegisterPage()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
## Summary
- redesign `LoginPage` with blurred background and animation
- add matching `RegisterPage`
- add entry/icon/button styles
- extend strings for onboarding
- register new routes and hide login from flyout
- add placeholder TODO for missing assets

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f789d87c8832fbe44ad818058417d