### PR TITLE
Redesign Routines page UI

### DIFF
--- a/GymMate/GymMate/Models/WorkoutRoutine.cs
+++ b/GymMate/GymMate/Models/WorkoutRoutine.cs
@@ -5,5 +5,7 @@ public class WorkoutRoutine
     public string Id { get; set; } = Guid.NewGuid().ToString();
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
+    public string Focus { get; set; } = "General";
+    public string Difficulty { get; set; } = "Básica";
     public DateTime CreatedUtc { get; set; } = DateTime.UtcNow;
 }

--- a/GymMate/GymMate/Resources/Strings/Strings.en.xaml
+++ b/GymMate/GymMate/Resources/Strings/Strings.en.xaml
@@ -49,4 +49,5 @@
     <sys:String x:Key="Tagline">Work out smarter</sys:String>
     <sys:String x:Key="Back">Back</sys:String>
     <sys:String x:Key="ConfirmPassword">Confirm password</sys:String>
+    <sys:String x:Key="NoRoutines">You have no routines yet</sys:String>
 </ResourceDictionary>

--- a/GymMate/GymMate/Resources/Strings/Strings.es.xaml
+++ b/GymMate/GymMate/Resources/Strings/Strings.es.xaml
@@ -49,4 +49,5 @@
     <sys:String x:Key="Tagline">Entrena con estilo</sys:String>
     <sys:String x:Key="Back">Volver</sys:String>
     <sys:String x:Key="ConfirmPassword">Confirmar contraseña</sys:String>
+    <sys:String x:Key="NoRoutines">Aún no tienes rutinas</sys:String>
 </ResourceDictionary>

--- a/GymMate/GymMate/Resources/Styles/Controls.xaml
+++ b/GymMate/GymMate/Resources/Styles/Controls.xaml
@@ -61,4 +61,18 @@
         <Setter Property="BackgroundColor" Value="Transparent" />
         <Setter Property="TextColor" Value="{DynamicResource PrimaryColor}" />
     </Style>
+
+    <!-- chip neutro -->
+    <Style x:Key="chip" TargetType="Label">
+        <Setter Property="BackgroundColor" Value="#FFFFFF33" />
+        <Setter Property="TextColor" Value="{DynamicResource TextColor}" />
+        <Setter Property="Padding" Value="8,2" />
+        <Setter Property="FontSize" Value="12" />
+        <Setter Property="CornerRadius" Value="12" />
+    </Style>
+    <!-- chip acento -->
+    <Style x:Key="chipAccent" TargetType="Label" BasedOn="{StaticResource chip}">
+        <Setter Property="BackgroundColor" Value="{DynamicResource AccentColor}" />
+        <Setter Property="TextColor" Value="White" />
+    </Style>
 </ResourceDictionary>

--- a/GymMate/GymMate/ViewModels/RoutineCardVm.cs
+++ b/GymMate/GymMate/ViewModels/RoutineCardVm.cs
@@ -1,0 +1,6 @@
+namespace GymMate.ViewModels;
+
+using GymMate.Models;
+
+public record RoutineCardVm(string Name, string Focus, string? Difficulty, DateTime CreatedUtc, WorkoutRoutine CommandParameter);
+

--- a/GymMate/GymMate/Views/RoutinesPage.xaml
+++ b/GymMate/GymMate/Views/RoutinesPage.xaml
@@ -2,37 +2,40 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:vm="clr-namespace:GymMate.ViewModels"
-             xmlns:models="clr-namespace:GymMate.Models"
+             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              x:Class="GymMate.Views.RoutinesPage"
              x:DataType="vm:RoutinesViewModel"
              x:Name="page">
-    <ContentPage.ToolbarItems>
-        <ToolbarItem Text="{DynamicResource Add}" Command="{Binding AddCommand}" />
-    </ContentPage.ToolbarItems>
-    <CollectionView ItemsSource="{Binding Routines}">
-        <CollectionView.ItemTemplate>
-            <DataTemplate x:DataType="models:WorkoutRoutine">
-                <SwipeView>
-                    <SwipeView.RightItems>
-                        <SwipeItems>
-                            <SwipeItem Text="{DynamicResource Edit}"
-                                       Command="{Binding Source={x:Reference page}, Path=BindingContext.EditCommand}"
-                                       CommandParameter="{Binding .}" />
-                            <SwipeItem Text="{DynamicResource Delete}" BackgroundColor="Red"
-                                       Command="{Binding Source={x:Reference page}, Path=BindingContext.DeleteCommand}"
-                                       CommandParameter="{Binding .}" />
-                        </SwipeItems>
-                    </SwipeView.RightItems>
-                    <Grid Padding="10">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                        </Grid.RowDefinitions>
-                        <Label Text="{Binding Name}" FontAttributes="Bold" />
-                        <Label Text="{Binding Description}" Grid.Row="1" FontSize="Small" />
-                    </Grid>
-                </SwipeView>
-            </DataTemplate>
-        </CollectionView.ItemTemplate>
-    </CollectionView>
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <toolkit:NullToBoolConverter x:Key="NullToBool" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <Grid RowDefinitions="Auto,*">
+        <Label Text="{DynamicResource Routines}" Style="{DynamicResource h1}" Padding="16,0" />
+        <CollectionView x:Name="RoutinesCV"
+                        Grid.Row="1"
+                        ItemsSource="{Binding Routines}"
+                        EmptyView="{DynamicResource NoRoutines}"
+                        ItemsLayout="VerticalGrid, 1">
+            <CollectionView.ItemTemplate>
+                <DataTemplate x:DataType="vm:RoutineCardVm">
+                    <Frame CornerRadius="16" Margin="16,8" HasShadow="False" BackgroundColor="{DynamicResource CardColor}">
+                        <VerticalStackLayout Padding="16" Spacing="12">
+                            <Label Text="{Binding Name}" Style="{DynamicResource subtitle}" />
+                            <HorizontalStackLayout Spacing="8">
+                                <Label Text="{Binding Focus}" Style="{DynamicResource chip}" />
+                                <Label Text="{Binding Difficulty}" Style="{DynamicResource chipAccent}" IsVisible="{Binding Difficulty, Converter={StaticResource NullToBool}}" />
+                            </HorizontalStackLayout>
+                            <Label Text="{Binding CreatedUtc, StringFormat='Creada {0:dd MMM yyyy}'}" Style="{DynamicResource caption}" Opacity="0.6" />
+                        </VerticalStackLayout>
+                        <Frame.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.EditRoutineCommand}" CommandParameter="{Binding .}" />
+                        </Frame.GestureRecognizers>
+                    </Frame>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+        <toolkit:FloatingActionButton WidthRequest="56" HeightRequest="56" Padding="0" CornerRadius="28" ImageSource="&#xe145;" FontFamily="MaterialIcons" FontSize="28" Command="{Binding AddRoutineCommand}" Margin="0,0,24,24" HorizontalOptions="End" VerticalOptions="End" />
+    </Grid>
 </ContentPage>

--- a/GymMate/GymMate/Views/RoutinesPage.xaml.cs
+++ b/GymMate/GymMate/Views/RoutinesPage.xaml.cs
@@ -1,4 +1,5 @@
 using GymMate.ViewModels;
+using System.Threading.Tasks;
 
 namespace GymMate.Views;
 
@@ -15,5 +16,15 @@ public partial class RoutinesPage : ContentPage
         base.OnAppearing();
         if (BindingContext is RoutinesViewModel vm)
             vm.AppearingCommand.Execute(null);
+
+        foreach (var v in RoutinesCV.VisibleViews)
+        {
+            v.TranslationX = 60;
+            v.Opacity = 0;
+        }
+        foreach (var v in RoutinesCV.VisibleViews)
+        {
+            _ = Task.WhenAll(v.TranslateTo(0, 0, 250), v.FadeTo(1, 250));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add Focus and Difficulty properties to WorkoutRoutine
- create RoutineCardVm for CollectionView
- update RoutinesViewModel to use RoutineCardVm and new commands
- redesign RoutinesPage with card layout and FAB
- animate routine cards on appearing
- add chip styles
- add `NoRoutines` localization string

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f7a705cf8832f85e9f0841389ce46