### PR TITLE
Implement iOS-style Settings page

### DIFF
--- a/GymMate/GymMate/Resources/Strings/Strings.en.xaml
+++ b/GymMate/GymMate/Resources/Strings/Strings.en.xaml
@@ -38,8 +38,12 @@
     <sys:String x:Key="Exercise">Exercise</sys:String>
     <sys:String x:Key="Reps">Reps</sys:String>
     <sys:String x:Key="Kg">Kg</sys:String>
-    <sys:String x:Key="DailyReminder">Training reminder</sys:String>
+    <sys:String x:Key="DailyReminder">Daily reminder</sys:String>
     <sys:String x:Key="NewPostNotifications">New post notifications</sys:String>
+    <sys:String x:Key="Notifications">Notifications</sys:String>
+    <sys:String x:Key="FeedPush">New posts</sys:String>
+    <sys:String x:Key="General">General</sys:String>
+    <sys:String x:Key="Language">Language</sys:String>
     <sys:String x:Key="Progress">Progress</sys:String>
     <sys:String x:Key="Rest">Rest</sys:String>
     <sys:String x:Key="Comments">Comments</sys:String>

--- a/GymMate/GymMate/Resources/Strings/Strings.es.xaml
+++ b/GymMate/GymMate/Resources/Strings/Strings.es.xaml
@@ -38,8 +38,12 @@
     <sys:String x:Key="Exercise">Ejercicio</sys:String>
     <sys:String x:Key="Reps">Reps</sys:String>
     <sys:String x:Key="Kg">Kg</sys:String>
-    <sys:String x:Key="DailyReminder">Recordatorio diario de entrenamiento</sys:String>
+    <sys:String x:Key="DailyReminder">Recordatorio diario</sys:String>
     <sys:String x:Key="NewPostNotifications">Notificaciones de nuevos posts</sys:String>
+    <sys:String x:Key="Notifications">Notificaciones</sys:String>
+    <sys:String x:Key="FeedPush">Nuevos posts</sys:String>
+    <sys:String x:Key="General">General</sys:String>
+    <sys:String x:Key="Language">Idioma</sys:String>
     <sys:String x:Key="Progress">Progreso</sys:String>
     <sys:String x:Key="Rest">Descanso</sys:String>
     <sys:String x:Key="Comments">Comentarios</sys:String>

--- a/GymMate/GymMate/Resources/Styles/Controls.xaml
+++ b/GymMate/GymMate/Resources/Styles/Controls.xaml
@@ -74,5 +74,12 @@
     <Style x:Key="chipAccent" TargetType="Label" BasedOn="{StaticResource chip}">
         <Setter Property="BackgroundColor" Value="{DynamicResource AccentColor}" />
         <Setter Property="TextColor" Value="White" />
+</Style>
+    <Style TargetType="SwitchCell">
+        <Setter Property="TextColor" Value="{DynamicResource TextColor}" />
+    </Style>
+    <Style TargetType="TextCell">
+        <Setter Property="TextColor" Value="{DynamicResource TextColor}" />
+        <Setter Property="DetailColor" Value="{DynamicResource TextColor}" />
     </Style>
 </ResourceDictionary>

--- a/GymMate/GymMate/Views/SettingsPage.xaml
+++ b/GymMate/GymMate/Views/SettingsPage.xaml
@@ -1,26 +1,39 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              xmlns:vm="clr-namespace:GymMate.ViewModels"
              x:Class="GymMate.Views.SettingsPage"
-             x:DataType="vm:SettingsViewModel">
-    <VerticalStackLayout Padding="30" Spacing="20">
-        <HorizontalStackLayout>
-            <Label Text="{DynamicResource NewPostNotifications}"
-                   VerticalOptions="Center" />
-            <Switch IsToggled="{Binding IsFeedPushEnabled}" />
-        </HorizontalStackLayout>
-        <HorizontalStackLayout>
-            <Label Text="{DynamicResource DailyReminder}"
-                   VerticalOptions="Center" />
-            <Switch IsToggled="{Binding IsDailyReminderEnabled}" />
-        </HorizontalStackLayout>
-        <TimePicker Time="{Binding ReminderTime}"
-                    Format="HH:mm"
-                    IsVisible="{Binding IsDailyReminderEnabled}" />
-        <Picker ItemsSource="{Binding Supported}"
-                ItemDisplayBinding="{Binding name}"
-                SelectedItem="{Binding SelectedLanguage}" />
-        <Button Text="{DynamicResource Save}" Command="{Binding SaveCommand}" />
-    </VerticalStackLayout>
+             x:DataType="vm:SettingsViewModel"
+             Title="{DynamicResource Settings}">
+
+    <toolkit:BottomSheet>
+        <toolkit:BottomSheet.HeaderTemplate>
+            <DataTemplate>
+                <Label Text="{DynamicResource Language}"
+                       FontAttributes="Bold" Margin="16,8" />
+            </DataTemplate>
+        </toolkit:BottomSheet.HeaderTemplate>
+    </toolkit:BottomSheet>
+
+    <TableRoot>
+        <TableSection Title="{DynamicResource Notifications}">
+            <SwitchCell
+                Text="{DynamicResource FeedPush}"
+                On="{Binding IsFeedPushEnabled}"
+                OnColor="{DynamicResource AccentColor}" />
+
+            <SwitchCell
+                Text="{DynamicResource DailyReminder}"
+                On="{Binding IsDailyReminderEnabled}"
+                OnColor="{DynamicResource AccentColor}" />
+        </TableSection>
+
+        <TableSection Title="{DynamicResource General}">
+            <TextCell
+                Text="{DynamicResource Language}"
+                Detail="{Binding CurrentLanguageName}"
+                Tapped="OnLanguageTapped" />
+        </TableSection>
+    </TableRoot>
 </ContentPage>

--- a/GymMate/GymMate/Views/SettingsPage.xaml.cs
+++ b/GymMate/GymMate/Views/SettingsPage.xaml.cs
@@ -16,4 +16,26 @@ public partial class SettingsPage : ContentPage
         if (BindingContext is SettingsViewModel vm)
             vm.AppearingCommand.Execute(null);
     }
+
+    private async void OnLanguageTapped(object sender, EventArgs e)
+    {
+        if (BindingContext is not SettingsViewModel vm)
+            return;
+
+        var picker = new Picker
+        {
+            ItemsSource = vm.LanguageNames,
+            SelectedItem = vm.CurrentLanguageName
+        };
+
+        picker.SelectedIndexChanged += async (_, __) =>
+        {
+            await vm.ChangeLanguageCommand.ExecuteAsync(picker.SelectedItem);
+            if (Application.Current.MainPage is IPage page)
+                page.HideBottomSheet();
+        };
+
+        if (Application.Current.MainPage is IPage p)
+            await p.ShowBottomSheetAsync(picker);
+    }
 }


### PR DESCRIPTION
## Summary
- redesign `SettingsPage` with `SwitchCell` and bottom sheet picker
- adjust `SettingsPage` code-behind to display picker in a bottom sheet
- expand `SettingsViewModel` with language names and command
- add new string resources for Settings page labels
- tweak controls style for table cells

## Testing
- `dotnet build GymMate.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f7d445f30832f826fe440aa3c5573