### PR TITLE
Implement login/register flows

### DIFF
--- a/GymMate/GymMate/MauiProgram.cs
+++ b/GymMate/GymMate/MauiProgram.cs
@@ -51,6 +51,10 @@ namespace GymMate
             builder.Services.AddSingleton<ILocalizationService, LocalizationService>();
             builder.Services.AddSingleton<IAnalyticsService, AnalyticsService>();
             builder.Services.AddSingleton<IFeedService, FeedService>();
+            builder.Services.AddTransient<ViewModels.LoginViewModel>();
+            builder.Services.AddTransient<Views.LoginPage>();
+            builder.Services.AddTransient<ViewModels.RegisterViewModel>();
+            builder.Services.AddTransient<Views.RegisterPage>();
             builder.Services.AddTransient<ViewModels.RestTimerViewModel>();
             builder.Services.AddTransient<Views.RestTimerPage>();
             builder.Services.AddTransient<ViewModels.RoutinesViewModel>();

--- a/GymMate/GymMate/ViewModels/LoginViewModel.cs
+++ b/GymMate/GymMate/ViewModels/LoginViewModel.cs
@@ -1,11 +1,18 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Maui.Alerts;
+using GymMate.Services;
 
 namespace GymMate.ViewModels;
 
 public partial class LoginViewModel : ObservableObject
 {
+    private readonly IFirebaseAuthService _auth;
+
+    public LoginViewModel(IFirebaseAuthService auth)
+    {
+        _auth = auth;
+    }
     [ObservableProperty]
     private string email = string.Empty;
 
@@ -24,6 +31,15 @@ public partial class LoginViewModel : ObservableObject
             await Toast.Make("Email/Password required").Show();
             return;
         }
-        // TODO: call auth service
+
+        var ok = await _auth.LoginAsync(Email, Password);
+        if (ok)
+        {
+            await Shell.Current.GoToAsync("//MainPage");
+        }
+        else
+        {
+            await Toast.Make("Login failed").Show();
+        }
     }
 }

--- a/GymMate/GymMate/ViewModels/RegisterViewModel.cs
+++ b/GymMate/GymMate/ViewModels/RegisterViewModel.cs
@@ -1,11 +1,18 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Maui.Alerts;
+using GymMate.Services;
 
 namespace GymMate.ViewModels;
 
 public partial class RegisterViewModel : ObservableObject
 {
+    private readonly IFirebaseAuthService _auth;
+
+    public RegisterViewModel(IFirebaseAuthService auth)
+    {
+        _auth = auth;
+    }
     [ObservableProperty]
     private string email = string.Empty;
 
@@ -34,6 +41,15 @@ public partial class RegisterViewModel : ObservableObject
             await Toast.Make("Passwords do not match").Show();
             return;
         }
-        // TODO: call auth service
+
+        var ok = await _auth.RegisterAsync(Email, Password);
+        if (ok)
+        {
+            await Shell.Current.GoToAsync("..");
+        }
+        else
+        {
+            await Toast.Make("Registration failed").Show();
+        }
     }
 }

--- a/GymMate/GymMate/Views/LoginPage.xaml
+++ b/GymMate/GymMate/Views/LoginPage.xaml
@@ -2,7 +2,10 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
-             x:Class="GymMate.Views.LoginPage">
+             xmlns:vm="clr-namespace:GymMate.ViewModels"
+             x:Class="GymMate.Views.LoginPage"
+             x:DataType="vm:LoginViewModel"
+             x:Name="page">
     <Grid>
         <!-- TODO: copy bg_gym.jpg into Resources/Images -->
         <Image Source="bg_gym.jpg" Aspect="AspectFill">
@@ -14,17 +17,24 @@
             <Image Source="logo.png" HeightRequest="120" />
             <Label Text="{DynamicResource Tagline}" Style="{DynamicResource h2}" />
             <Frame CornerRadius="24" Padding="24" BackgroundColor="#FFFFFFAA">
-                <Entry Style="{DynamicResource entryIcon}" Placeholder="{DynamicResource Email}">
+                <Entry Style="{DynamicResource entryIcon}"
+                       Placeholder="{DynamicResource Email}"
+                       Text="{Binding Email}">
                     <Entry.FontImageSource>
                         <FontImageSource Glyph="&#xe158;" />
                     </Entry.FontImageSource>
                 </Entry>
-                <Entry Style="{DynamicResource entryIcon}" Placeholder="{DynamicResource Password}" IsPassword="True">
+                <Entry Style="{DynamicResource entryIcon}"
+                       Placeholder="{DynamicResource Password}"
+                       IsPassword="True"
+                       Text="{Binding Password}">
                     <Entry.FontImageSource>
                         <FontImageSource Glyph="&#xe897;" />
                     </Entry.FontImageSource>
                 </Entry>
-                <Button Text="{DynamicResource Login}" Style="{DynamicResource primaryButton}" />
+                <Button Text="{DynamicResource Login}"
+                        Style="{DynamicResource primaryButton}"
+                        Command="{Binding LoginCommand}" />
             </Frame>
             <Button Text="{DynamicResource Register}" Style="{DynamicResource linkButton}" Command="{Binding NavigateRegisterCommand}" />
         </VerticalStackLayout>

--- a/GymMate/GymMate/Views/LoginPage.xaml.cs
+++ b/GymMate/GymMate/Views/LoginPage.xaml.cs
@@ -1,10 +1,13 @@
+using GymMate.ViewModels;
+
 namespace GymMate.Views;
 
 public partial class LoginPage : ContentPage
 {
-    public LoginPage()
+    public LoginPage(LoginViewModel viewModel)
     {
         InitializeComponent();
+        BindingContext = viewModel;
     }
 
     protected override async void OnAppearing()

--- a/GymMate/GymMate/Views/RegisterPage.xaml
+++ b/GymMate/GymMate/Views/RegisterPage.xaml
@@ -2,7 +2,10 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
-             x:Class="GymMate.Views.RegisterPage">
+             xmlns:vm="clr-namespace:GymMate.ViewModels"
+             x:Class="GymMate.Views.RegisterPage"
+             x:DataType="vm:RegisterViewModel"
+             x:Name="page">
     <Grid>
         <!-- TODO: copy bg_gym.jpg into Resources/Images -->
         <Image Source="bg_gym.jpg" Aspect="AspectFill">
@@ -14,22 +17,32 @@
             <Image Source="logo.png" HeightRequest="120" />
             <Label Text="{DynamicResource Tagline}" Style="{DynamicResource h2}" />
             <Frame CornerRadius="24" Padding="24" BackgroundColor="#FFFFFFAA">
-                <Entry Style="{DynamicResource entryIcon}" Placeholder="{DynamicResource Email}">
+                <Entry Style="{DynamicResource entryIcon}"
+                       Placeholder="{DynamicResource Email}"
+                       Text="{Binding Email}">
                     <Entry.FontImageSource>
                         <FontImageSource Glyph="&#xe158;" />
                     </Entry.FontImageSource>
                 </Entry>
-                <Entry Style="{DynamicResource entryIcon}" Placeholder="{DynamicResource Password}" IsPassword="True">
+                <Entry Style="{DynamicResource entryIcon}"
+                       Placeholder="{DynamicResource Password}"
+                       IsPassword="True"
+                       Text="{Binding Password}">
                     <Entry.FontImageSource>
                         <FontImageSource Glyph="&#xe897;" />
                     </Entry.FontImageSource>
                 </Entry>
-                <Entry Style="{DynamicResource entryIcon}" Placeholder="{DynamicResource ConfirmPassword}" IsPassword="True">
+                <Entry Style="{DynamicResource entryIcon}"
+                       Placeholder="{DynamicResource ConfirmPassword}"
+                       IsPassword="True"
+                       Text="{Binding ConfirmPassword}">
                     <Entry.FontImageSource>
                         <FontImageSource Glyph="&#xe897;" />
                     </Entry.FontImageSource>
                 </Entry>
-                <Button Text="{DynamicResource Register}" Style="{DynamicResource primaryButton}" />
+                <Button Text="{DynamicResource Register}"
+                        Style="{DynamicResource primaryButton}"
+                        Command="{Binding RegisterCommand}" />
             </Frame>
             <Button Text="{DynamicResource Back}" Style="{DynamicResource linkButton}" Command="{Binding NavigateBackCommand}" />
         </VerticalStackLayout>

--- a/GymMate/GymMate/Views/RegisterPage.xaml.cs
+++ b/GymMate/GymMate/Views/RegisterPage.xaml.cs
@@ -1,9 +1,12 @@
+using GymMate.ViewModels;
+
 namespace GymMate.Views;
 
 public partial class RegisterPage : ContentPage
 {
-    public RegisterPage()
+    public RegisterPage(RegisterViewModel viewModel)
     {
         InitializeComponent();
+        BindingContext = viewModel;
     }
 }


### PR DESCRIPTION
## Summary
- enable DI for login and register pages
- bind fields and commands in `LoginPage` and `RegisterPage`
- hook login and register viewmodels with `FirebaseAuthService`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684fbae4ff3c832fac43d0dd69fc7fbe