### PR TITLE
Update theme handling for MAUI app

### DIFF
--- a/GymMate/GymMate/App.xaml.cs
+++ b/GymMate/GymMate/App.xaml.cs
@@ -10,16 +10,39 @@ namespace GymMate
         public App()
         {
             InitializeComponent();
+
             var code = Preferences.Get("LanguageCode", null) ?? CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
             var dict = Application.Current.Resources.MergedDictionaries
                 .First(md => md.Keys.Contains(code));
             Application.Current.Resources.MergedDictionaries.Remove(dict);
             Application.Current.Resources.MergedDictionaries.Add(dict);
+
             Application.Current.UserAppTheme = AppTheme.Unspecified;
+
+            ApplyTheme();
+
             Application.Current.RequestedThemeChanged += (s, e) =>
             {
-                MainPage = new AppShell();
+                ApplyTheme();
             };
+        }
+
+        private static void ApplyTheme()
+        {
+            var dictionaries = Application.Current.Resources.MergedDictionaries;
+            var themeDicts = dictionaries
+                .Where(md => md is Resources.Themes.LightColors || md is Resources.Themes.DarkColors)
+                .ToList();
+            foreach (var md in themeDicts)
+            {
+                dictionaries.Remove(md);
+            }
+
+            var newDict = Application.Current.RequestedTheme == AppTheme.Dark
+                ? new Resources.Themes.DarkColors()
+                : new Resources.Themes.LightColors();
+
+            dictionaries.Insert(0, newDict);
         }
 
         protected override Window CreateWindow(IActivationState? activationState)


### PR DESCRIPTION
## Summary
- add a helper method to load theme resource dictionaries
- update RequestedThemeChanged handler to call new method

## Testing
- `dotnet build GymMate.sln -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fe6415a68832f84a00d665daffa65