### PR TITLE
Implement Firestore feed backend

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -21,6 +21,20 @@ service cloud.firestore {
       allow read: if true; // consultas whereIn + orderBy
       allow write: if request.auth != null
                    && request.resource.data.AuthorUid == request.auth.uid;
+
+      match /likes/{uid} {
+        allow read: if true;
+        allow write: if request.auth != null && request.auth.uid == uid;
+        allow delete: if request.auth != null && request.auth.uid == uid;
+      }
+
+      match /comments/{commentId} {
+        allow read: if true;
+        allow write: if request.auth != null
+                     && request.resource.data.AuthorUid == request.auth.uid;
+        allow delete: if request.auth != null
+                       && request.auth.uid == resource.data.AuthorUid;
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- store feed posts, comments and likes in Firestore
- allow querying posts of followed users via `WhereIn`
- use subcollections for post likes and comments
- notify post authors on new comments
- update Firestore rules for `feedPosts`

## Testing
- `dotnet build GymMate/GymMate/GymMate.csproj -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684febb03508832fbc364b7934a96b64