### PR TITLE
Implement follower notifications

### DIFF
--- a/GymMate/GymMate/Services/FeedService.cs
+++ b/GymMate/GymMate/Services/FeedService.cs
@@ -121,6 +121,10 @@ public class FeedService : IFeedService
         await _firestore.Collection("feedPosts").Document(post.Id).SetAsync(post);
         _posts[post.Id] = post;
         await _localDb.SavePostsAsync(new[] { post });
+        await foreach (var follower in _follow.GetFollowersAsync(uid))
+        {
+            await _notifications.SendAsync($"user_{follower}", "Nuevo post", profile.DisplayName);
+        }
         PostUpdated?.Invoke(this, post);
     }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -15,6 +15,10 @@ service cloud.firestore {
         allow read: if true;
         allow write, delete: if request.auth.uid == uid;
       }
+
+      match /deviceTokens/{token} {
+        allow read, write, delete: if request.auth != null && request.auth.uid == uid;
+      }
     }
 
     match /feedPosts/{postId} {


### PR DESCRIPTION
## Summary
- send FCM messages to followers when creating a new post
- expose SendAsync for FCM sending in NotificationService
- store refreshed device tokens under each user
- restrict deviceTokens collection in Firestore rules

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ff7593d04832fbcc1adbf3b7d7262